### PR TITLE
貸出履歴のAPIを実装した

### DIFF
--- a/api/components/schemas/Loan.yml
+++ b/api/components/schemas/Loan.yml
@@ -7,11 +7,11 @@ properties:
   volume:
     type: integer
   createdAt:
-    type: string
-    format: date-time
+    type: integer
+    description: レコードが作成されたUNIX時間
   updatedAt:
-    type: string
-    format: date-time
+    type: integer
+    description: レコードが最後に更新されたUNIX時間
 required:
   - userId
   - bookId

--- a/api/components/schemas/Loan.yml
+++ b/api/components/schemas/Loan.yml
@@ -1,7 +1,5 @@
 type: object
 properties:
-  id:
-    type: integer
   userId:
     type: integer
   bookId:
@@ -15,7 +13,6 @@ properties:
     type: string
     format: date-time
 required:
-  - id
   - userId
   - bookId
   - volume

--- a/api/paths/auth.yml
+++ b/api/paths/auth.yml
@@ -47,6 +47,8 @@ auth:
                 $ref: "../components/examples/user.yml"
       '400':
         $ref: "../components/responses/4xx.yml#/BadRequest"
+      '401':
+        $ref: "../components/responses/4xx.yml#/Unauthorized"
       '404':
         $ref: "../components/responses/4xx.yml#/NotFound"
       '500':

--- a/api/paths/book.yml
+++ b/api/paths/book.yml
@@ -158,7 +158,7 @@ book:
       '500':
         $ref: "../components/responses/5xx.yml#/InternalServerError"
 
-  put:
+  patch:
     tags:
       - book
     operationId: updateBook

--- a/api/paths/book.yml
+++ b/api/paths/book.yml
@@ -115,9 +115,10 @@ books:
         content:
           application/json:
             schema:
-              $ref: "../components/schemas/Error.yml"
-            example:
-              message: "Created"
+              $ref: "../components/schemas/Book.yml"
+            examples:
+              book:
+                $ref: "../components/examples/book.yml"
       '400':
         $ref: "../components/responses/4xx.yml#/BadRequest"
       '401':

--- a/api/paths/loan.yml
+++ b/api/paths/loan.yml
@@ -56,11 +56,11 @@ loans:
       '500':
         $ref: "../components/responses/5xx.yml#/InternalServerError"
 
-  post:
+  patch:
     tags:
       - loan
-    operationId: createLoans
-    summary: 貸出履歴を追加する
+    operationId: upsertLoans
+    summary: 貸出履歴を更新する
     security:
       - CookieAuth: []
     requestBody:
@@ -78,7 +78,6 @@ loans:
                   type: integer
                 volume:
                   type: integer
-                  minimum: 1
               required:
                 - userId
                 - bookId
@@ -89,29 +88,35 @@ loans:
         content:
           application/json:
             schema:
-              $ref: "../components/schemas/Loan.yml"
+              type: array
+              items:
+                $ref: "../components/schemas/Loan.yml"
       '400':
         $ref: "../components/responses/4xx.yml#/BadRequest"
       '401':
         $ref: "../components/responses/4xx.yml#/Unauthorized"
-      '500':
-        $ref: "../components/responses/5xx.yml#/InternalServerError"
-
-  put:
-    tags:
-      - loan
-    operationId: updateLoans
-    summary: 貸出履歴を更新する
-    description: リクエストボディに含まれている情報のみ更新する
-    security:
-      - CookieAuth: []
-    requestBody:
-      required: true
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
+      '404':
+        description: ユーザーまたは書籍が存在しない
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: integer
+                bookId:
+                  type: integer
+              required:
+                - userId
+                - bookId
+      '409':
+        description: >
+          貸出数が在庫数を超えている．
+          返却数が貸出数を超えている．
+        content:
+          application/json:
+            schema:
+              description: 貸出数が在庫数を超えているリクエスト
               type: object
               properties:
                 userId:
@@ -123,16 +128,6 @@ loans:
               required:
                 - userId
                 - bookId
-    responses:
-      '200':
-        description: OK
-        content:
-          application/json:
-            schema:
-              $ref: "../components/schemas/Loan.yml"
-      '400':
-        $ref: "../components/responses/4xx.yml#/BadRequest"
-      '401':
-        $ref: "../components/responses/4xx.yml#/Unauthorized"
+                - volume
       '500':
         $ref: "../components/responses/5xx.yml#/InternalServerError"

--- a/api/paths/user.yml
+++ b/api/paths/user.yml
@@ -141,7 +141,7 @@ user:
       '500':
         $ref: "../components/responses/5xx.yml#/InternalServerError"
 
-  put:
+  patch:
     tags:
       - user
     operationId: updateUser

--- a/api/paths/user.yml
+++ b/api/paths/user.yml
@@ -90,12 +90,10 @@ users:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                message:
-                  type: string
-            example:
-              message: "Created"
+              $ref: "../components/schemas/User.yml"
+            examples:
+              user:
+                $ref: "../components/examples/user.yml"
       '400':
         $ref: "../components/responses/4xx.yml#/BadRequest"
       '401':

--- a/backend/README.md
+++ b/backend/README.md
@@ -50,6 +50,14 @@ pnpm run test
 pnpm run deploy
 ```
 
+## wrangler
+
+### d1
+
+```
+npx wrangler d1 execute <database_name> (--command=<query> | --file=*.sql)
+```
+
 ## drizzle-orm
 
 マイグレーションのロールバック

--- a/backend/drizzle/migrations/0006_flashy_proteus.sql
+++ b/backend/drizzle/migrations/0006_flashy_proteus.sql
@@ -4,7 +4,7 @@ CREATE TABLE `loans` (
 	`volume` integer DEFAULT 1 NOT NULL,
 	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
 	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
-	PRIMARY KEY(`book_id`, `user_id`),
+	PRIMARY KEY(`user_id`, `book_id`),
 	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
 	FOREIGN KEY (`book_id`) REFERENCES `books`(`id`) ON UPDATE no action ON DELETE cascade
 );

--- a/backend/drizzle/migrations/0006_flashy_proteus.sql
+++ b/backend/drizzle/migrations/0006_flashy_proteus.sql
@@ -2,8 +2,8 @@ CREATE TABLE `loans` (
 	`user_id` integer NOT NULL,
 	`book_id` integer NOT NULL,
 	`volume` integer DEFAULT 1 NOT NULL,
-	`created_at` text DEFAULT (datetime(current_timestamp, '+9 hours')) NOT NULL,
-	`updated_at` text DEFAULT (datetime(current_timestamp, '+9 hours')) NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
 	PRIMARY KEY(`book_id`, `user_id`),
 	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
 	FOREIGN KEY (`book_id`) REFERENCES `books`(`id`) ON UPDATE no action ON DELETE cascade

--- a/backend/drizzle/migrations/0006_mysterious_boomerang.sql
+++ b/backend/drizzle/migrations/0006_mysterious_boomerang.sql
@@ -1,10 +1,10 @@
 CREATE TABLE `loans` (
-	`book_id` integer NOT NULL,
 	`user_id` integer NOT NULL,
+	`book_id` integer NOT NULL,
 	`volume` integer DEFAULT 1 NOT NULL,
 	`created_at` text DEFAULT (datetime(current_timestamp, '+9 hours')) NOT NULL,
 	`updated_at` text DEFAULT (datetime(current_timestamp, '+9 hours')) NOT NULL,
 	PRIMARY KEY(`book_id`, `user_id`),
-	FOREIGN KEY (`book_id`) REFERENCES `books`(`id`) ON UPDATE no action ON DELETE cascade,
-	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`book_id`) REFERENCES `books`(`id`) ON UPDATE no action ON DELETE cascade
 );

--- a/backend/drizzle/migrations/0006_mysterious_boomerang.sql
+++ b/backend/drizzle/migrations/0006_mysterious_boomerang.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `loans` (
+	`book_id` integer NOT NULL,
+	`user_id` integer NOT NULL,
+	`volume` integer DEFAULT 1 NOT NULL,
+	`created_at` text DEFAULT (datetime(current_timestamp, '+9 hours')) NOT NULL,
+	`updated_at` text DEFAULT (datetime(current_timestamp, '+9 hours')) NOT NULL,
+	PRIMARY KEY(`book_id`, `user_id`),
+	FOREIGN KEY (`book_id`) REFERENCES `books`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/backend/drizzle/migrations/meta/0006_snapshot.json
+++ b/backend/drizzle/migrations/meta/0006_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "22b51ce3-97a9-40af-8271-cea46f1daf68",
+  "id": "918dee07-debf-48ab-9658-616933d0a0d1",
   "prevId": "69f74fa0-6b9a-4f27-8446-9ac14bbed137",
   "tables": {
     "books": {
@@ -81,15 +81,15 @@
     "loans": {
       "name": "loans",
       "columns": {
-        "book_id": {
-          "name": "book_id",
+        "user_id": {
+          "name": "user_id",
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false
         },
-        "user_id": {
-          "name": "user_id",
+        "book_id": {
+          "name": "book_id",
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
@@ -105,29 +105,29 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "text",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false,
-          "default": "(datetime(current_timestamp, '+9 hours'))"
+          "default": "(unixepoch())"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "text",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false,
-          "default": "(datetime(current_timestamp, '+9 hours'))"
+          "default": "(unixepoch())"
         }
       },
       "indexes": {},
       "foreignKeys": {
-        "loans_book_id_books_id_fk": {
-          "name": "loans_book_id_books_id_fk",
+        "loans_user_id_users_id_fk": {
+          "name": "loans_user_id_users_id_fk",
           "tableFrom": "loans",
-          "tableTo": "books",
+          "tableTo": "users",
           "columnsFrom": [
-            "book_id"
+            "user_id"
           ],
           "columnsTo": [
             "id"
@@ -135,12 +135,12 @@
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
-        "loans_user_id_users_id_fk": {
-          "name": "loans_user_id_users_id_fk",
+        "loans_book_id_books_id_fk": {
+          "name": "loans_book_id_books_id_fk",
           "tableFrom": "loans",
-          "tableTo": "users",
+          "tableTo": "books",
           "columnsFrom": [
-            "user_id"
+            "book_id"
           ],
           "columnsTo": [
             "id"

--- a/backend/drizzle/migrations/meta/0006_snapshot.json
+++ b/backend/drizzle/migrations/meta/0006_snapshot.json
@@ -1,0 +1,225 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "22b51ce3-97a9-40af-8271-cea46f1daf68",
+  "prevId": "69f74fa0-6b9a-4f27-8446-9ac14bbed137",
+  "tables": {
+    "books": {
+      "name": "books",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isbn": {
+          "name": "isbn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "books_isbn_unique": {
+          "name": "books_isbn_unique",
+          "columns": [
+            "isbn"
+          ],
+          "isUnique": true
+        },
+        "isbn_idx": {
+          "name": "isbn_idx",
+          "columns": [
+            "isbn"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "loans": {
+      "name": "loans",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime(current_timestamp, '+9 hours'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime(current_timestamp, '+9 hours'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "loans_book_id_books_id_fk": {
+          "name": "loans_book_id_books_id_fk",
+          "tableFrom": "loans",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "loans_user_id_users_id_fk": {
+          "name": "loans_user_id_users_id_fk",
+          "tableFrom": "loans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "loans_book_id_user_id_pk": {
+          "columns": [
+            "book_id",
+            "user_id"
+          ],
+          "name": "loans_book_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_digest": {
+          "name": "password_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/backend/drizzle/migrations/meta/_journal.json
+++ b/backend/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1728874463479,
       "tag": "0005_needy_charles_xavier",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1729158290879,
+      "tag": "0006_mysterious_boomerang",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/drizzle/migrations/meta/_journal.json
+++ b/backend/drizzle/migrations/meta/_journal.json
@@ -47,8 +47,8 @@
     {
       "idx": 6,
       "version": "6",
-      "when": 1729158290879,
-      "tag": "0006_mysterious_boomerang",
+      "when": 1729175828297,
+      "tag": "0006_flashy_proteus",
       "breakpoints": true
     }
   ]

--- a/backend/drizzle/schema.ts
+++ b/backend/drizzle/schema.ts
@@ -1,4 +1,4 @@
-import { relations } from 'drizzle-orm';
+import { relations, sql } from 'drizzle-orm';
 import {
 	integer,
 	primaryKey,
@@ -71,6 +71,12 @@ export const loanTable = sqliteTable(
 			.notNull()
 			.references(() => userTable.id, { onDelete: 'cascade' }),
 		volume: integer('volume').notNull().default(1),
+		createdAt: text('created_at')
+			.notNull()
+			.default(sql`(datetime(current_timestamp, '+9 hours'))`),
+		updatedAt: text('updated_at')
+			.notNull()
+			.default(sql`(datetime(current_timestamp, '+9 hours'))`),
 	},
 	(table) => {
 		return {
@@ -78,3 +84,6 @@ export const loanTable = sqliteTable(
 		};
 	}
 );
+
+export type SelectLoan = typeof loanTable.$inferSelect;
+export type InsertLoan = typeof loanTable.$inferInsert;

--- a/backend/drizzle/schema.ts
+++ b/backend/drizzle/schema.ts
@@ -1,5 +1,7 @@
+import { relations } from 'drizzle-orm';
 import {
 	integer,
+	primaryKey,
 	sqliteTable,
 	text,
 	uniqueIndex,
@@ -24,6 +26,14 @@ export const bookTable = sqliteTable(
 export type SelectBook = typeof bookTable.$inferSelect;
 export type InsertBook = typeof bookTable.$inferInsert;
 
+// prettier-ignore
+export const booksRelation = relations(
+	bookTable,
+	({ many }) => ({
+		booksToUsers: many(loanTable),
+	})
+);
+
 export const userTable = sqliteTable(
 	'users',
 	{
@@ -42,3 +52,33 @@ export const userTable = sqliteTable(
 
 export type SelectUser = typeof userTable.$inferSelect;
 export type InsertUser = typeof userTable.$inferInsert;
+
+// prettier-ignore
+export const usersRelation = relations(
+	userTable,
+	({ many }) => ({
+		usersToBooks: many(loanTable),
+	})
+);
+
+export const loanTable = sqliteTable(
+	'loans',
+	{
+		bookId: integer('book_id')
+			.notNull()
+			.references(() => {
+				return bookTable.id;
+			}),
+		userId: integer('user_id')
+			.notNull()
+			.references(() => {
+				return userTable.id;
+			}),
+		volume: integer('volume').notNull().default(1),
+	},
+	(table) => {
+		return {
+			pk: primaryKey({ columns: [table.bookId, table.userId] }),
+		};
+	}
+);

--- a/backend/drizzle/schema.ts
+++ b/backend/drizzle/schema.ts
@@ -64,12 +64,12 @@ export const usersRelation = relations(
 export const loanTable = sqliteTable(
 	'loans',
 	{
-		bookId: integer('book_id')
-			.notNull()
-			.references(() => bookTable.id, { onDelete: 'cascade' }),
 		userId: integer('user_id')
 			.notNull()
 			.references(() => userTable.id, { onDelete: 'cascade' }),
+		bookId: integer('book_id')
+			.notNull()
+			.references(() => bookTable.id, { onDelete: 'cascade' }),
 		volume: integer('volume').notNull().default(1),
 		createdAt: text('created_at')
 			.notNull()
@@ -87,3 +87,18 @@ export const loanTable = sqliteTable(
 
 export type SelectLoan = typeof loanTable.$inferSelect;
 export type InsertLoan = typeof loanTable.$inferInsert;
+
+// prettier-ignore
+export const usersToBooksRelations = relations(
+	loanTable,
+	({ one }) => ({
+		user: one(userTable, {
+			fields: [loanTable.userId],
+			references: [userTable.id],
+		}),
+		book: one(bookTable, {
+			fields: [loanTable.bookId],
+			references: [bookTable.id],
+		}),
+	})
+);

--- a/backend/drizzle/schema.ts
+++ b/backend/drizzle/schema.ts
@@ -66,14 +66,10 @@ export const loanTable = sqliteTable(
 	{
 		bookId: integer('book_id')
 			.notNull()
-			.references(() => {
-				return bookTable.id;
-			}),
+			.references(() => bookTable.id, { onDelete: 'cascade' }),
 		userId: integer('user_id')
 			.notNull()
-			.references(() => {
-				return userTable.id;
-			}),
+			.references(() => userTable.id, { onDelete: 'cascade' }),
 		volume: integer('volume').notNull().default(1),
 	},
 	(table) => {

--- a/backend/drizzle/schema.ts
+++ b/backend/drizzle/schema.ts
@@ -71,12 +71,12 @@ export const loanTable = sqliteTable(
 			.notNull()
 			.references(() => bookTable.id, { onDelete: 'cascade' }),
 		volume: integer('volume').notNull().default(1),
-		createdAt: text('created_at')
+		createdAt: integer('created_at', { mode: 'number' })
 			.notNull()
-			.default(sql`(datetime(current_timestamp, '+9 hours'))`),
-		updatedAt: text('updated_at')
+			.default(sql`(unixepoch())`),
+		updatedAt: integer('updated_at', { mode: 'number' })
 			.notNull()
-			.default(sql`(datetime(current_timestamp, '+9 hours'))`),
+			.default(sql`(unixepoch())`),
 	},
 	(table) => {
 		return {

--- a/backend/drizzle/schema.ts
+++ b/backend/drizzle/schema.ts
@@ -80,7 +80,7 @@ export const loanTable = sqliteTable(
 	},
 	(table) => {
 		return {
-			pk: primaryKey({ columns: [table.bookId, table.userId] }),
+			pk: primaryKey({ columns: [table.userId, table.bookId] }),
 		};
 	}
 );

--- a/backend/drizzle/seeds/book.sql
+++ b/backend/drizzle/seeds/book.sql
@@ -1,8 +1,8 @@
 INSERT INTO
     books (title, authors, publisher, thumbnail, isbn, stock)
 VALUES
-    ('コンピュータプログラミングの基礎', json_array('山田 太郎', '佐藤 花子'), '技術評論社', 'https://example.com/thumbnail1.jpg', '9781234567890', 3),
-    ('ソフトウェア設計入門', json_array('高橋 一郎'), 'オーム社', 'https://example.com/thumbnail2.jpg', '9780987654321', 2),
-    ('データベースシステム', json_array('鈴木 二郎', '田中 三郎'), '日経BP', 'https://example.com/thumbnail3.jpg', '9782345678901', 5),
-    ('ネットワーク技術の基礎', json_array('佐藤 四郎'), '翔泳社', 'https://example.com/thumbnail4.jpg', '9783456789012', 4),
-    ('アルゴリズムとデータ構造', json_array('中村 五郎', '伊藤 六郎'), '森北出版', 'https://example.com/thumbnail5.jpg', '9784567890123', 6);
+    ('コンピュータプログラミングの基礎', json_array('山田 太郎', '佐藤 花子'), '技術評論社', 'https://example.com/thumbnail1.jpg', '9781234567890', 1),
+    ('ソフトウェア設計入門', json_array('高橋 一郎'), 'オーム社', 'https://example.com/thumbnail2.jpg', '9780987654321', 1),
+    ('データベースシステム', json_array('鈴木 二郎', '田中 三郎'), '日経BP', 'https://example.com/thumbnail3.jpg', '9782345678901', 1),
+    ('ネットワーク技術の基礎', json_array('佐藤 四郎'), '翔泳社', 'https://example.com/thumbnail4.jpg', '9783456789012', 2),
+    ('アルゴリズムとデータ構造', json_array('中村 五郎', '伊藤 六郎'), '森北出版', 'https://example.com/thumbnail5.jpg', '9784567890123', 3);

--- a/backend/drizzle/seeds/loan.sql
+++ b/backend/drizzle/seeds/loan.sql
@@ -1,0 +1,24 @@
+INSERT INTO
+    books (title, authors, publisher, thumbnail, isbn, stock)
+VALUES
+    ('機械学習入門', json_array('山田 一郎'), '技術評論社', 'https://example.com/thumbnail6.jpg', '9781234567899', 4),
+    ('AIプログラミングの基礎', json_array('佐々木 二郎'), 'オーム社', 'https://example.com/thumbnail7.jpg', '9780987654330', 5),
+    ('ネットワークセキュリティ', json_array('高橋 三郎'), '日経BP', 'https://example.com/thumbnail8.jpg', '9782345678910', 2);
+
+INSERT INTO
+    users (name, email, password_digest)
+VALUES
+    ('小林花子', 'hanako.kobayashi@example.com', 'd41d8cd98f00b204e9800998ecf8427e'),
+    ('山田一郎', 'ichiro.yamada@example.com', '5d41402abc4b2a76b9719d911017c592');
+
+INSERT INTO
+    loans (user_id, book_id, volume)
+VALUES
+    -- 小林花子が機械学習入門を貸出
+    (1, 1, 1),
+    -- 小林花子がAIプログラミングの基礎を貸出
+    (1, 2, 1),
+    -- 山田一郎がAIプログラミングの基礎を貸出
+    (2, 2, 1),
+    -- 山田一郎がネットワークセキュリティを貸出
+    (2, 3, 1);

--- a/backend/drizzle/seeds/loan.sql
+++ b/backend/drizzle/seeds/loan.sql
@@ -1,24 +1,7 @@
 INSERT INTO
-    books (title, authors, publisher, thumbnail, isbn, stock)
-VALUES
-    ('機械学習入門', json_array('山田 一郎'), '技術評論社', 'https://example.com/thumbnail6.jpg', '9781234567899', 4),
-    ('AIプログラミングの基礎', json_array('佐々木 二郎'), 'オーム社', 'https://example.com/thumbnail7.jpg', '9780987654330', 5),
-    ('ネットワークセキュリティ', json_array('高橋 三郎'), '日経BP', 'https://example.com/thumbnail8.jpg', '9782345678910', 2);
-
-INSERT INTO
-    users (name, email, password_digest)
-VALUES
-    ('小林花子', 'hanako.kobayashi@example.com', 'd41d8cd98f00b204e9800998ecf8427e'),
-    ('山田一郎', 'ichiro.yamada@example.com', '5d41402abc4b2a76b9719d911017c592');
-
-INSERT INTO
     loans (user_id, book_id, volume)
 VALUES
-    -- 小林花子が機械学習入門を貸出
     (1, 1, 1),
-    -- 小林花子がAIプログラミングの基礎を貸出
     (1, 2, 1),
-    -- 山田一郎がAIプログラミングの基礎を貸出
     (2, 2, 1),
-    -- 山田一郎がネットワークセキュリティを貸出
     (2, 3, 1);

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@hono/zod-validator": "^0.3.0",
+    "camelcase": "^8.0.0",
     "drizzle-orm": "^0.33.0",
     "hono": "^4.6.3",
     "zod": "^3.23.8"

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hono/zod-validator':
         specifier: ^0.3.0
         version: 0.3.0(hono@4.6.3)(zod@3.23.8)
+      camelcase:
+        specifier: ^8.0.0
+        version: 8.0.0
       drizzle-orm:
         specifier: ^0.33.0
         version: 0.33.0(@cloudflare/workers-types@4.20241004.0)(better-sqlite3@11.3.0)
@@ -1269,6 +1272,10 @@ packages:
 
   call-me-maybe@1.0.2:
     resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
 
   capnp-ts@0.7.0:
     resolution: {integrity: sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==}
@@ -3680,6 +3687,8 @@ snapshots:
       set-function-length: 1.2.2
 
   call-me-maybe@1.0.2: {}
+
+  camelcase@8.0.0: {}
 
   capnp-ts@0.7.0:
     dependencies:

--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -17,6 +17,7 @@ app.post(
 			return ctx.json(
 				{
 					message: 'Request Body Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -70,6 +71,7 @@ app.post(
 
 		const result = loginResponse.safeParse(selectUser[0]);
 		if (!result.success) {
+			console.error(result.error);
 			return ctx.json(
 				{
 					message: 'Response Validation Error',
@@ -84,12 +86,7 @@ app.post(
 
 app.delete('/', async (ctx) => {
 	await logout(ctx);
-	return ctx.json(
-		{
-			message: 'Goodbye',
-		},
-		200
-	);
+	return ctx.json({ message: 'Goodbye' }, 200);
 });
 
 export default app;

--- a/backend/src/api/book.ts
+++ b/backend/src/api/book.ts
@@ -305,7 +305,7 @@ app.get(
 	}
 );
 
-app.put(
+app.patch(
 	'/:bookId',
 	zValidator('param', updateBookParams, (result, ctx) => {
 		if (!result.success) {

--- a/backend/src/api/book.ts
+++ b/backend/src/api/book.ts
@@ -21,7 +21,7 @@ import { isLoggedIn } from '../utils/auth';
 const app = new Hono<{ Bindings: Env }>();
 
 // Google Books APIのレスポンス
-type GBAResult = {
+interface GBAResult {
 	items?: [
 		{
 			volumeInfo: {
@@ -38,16 +38,16 @@ type GBAResult = {
 			};
 		}
 	];
-};
+}
 
 // GET /search のレスポンス
-type GoogleBook = {
+interface GoogleBook {
 	title: string;
 	authors: string[];
 	publisher: string;
 	thumbnail: string;
 	isbn: string;
-};
+}
 
 app.get(
 	'/search',

--- a/backend/src/api/book.ts
+++ b/backend/src/api/book.ts
@@ -56,6 +56,7 @@ app.get(
 			return ctx.json(
 				{
 					message: 'Query Parameter Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -127,6 +128,7 @@ app.get(
 
 		const result = searchBooksResponse.safeParse(hitBooks);
 		if (!result.success) {
+			console.error(result.error);
 			return ctx.json(
 				{
 					message: 'Response Validation Error',
@@ -146,6 +148,7 @@ app.get(
 			return ctx.json(
 				{
 					message: 'Query Parameter Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -183,6 +186,7 @@ app.get(
 
 		const result = getBooksResponse.safeParse(books);
 		if (!result.success) {
+			console.error(result.error);
 			return ctx.json(
 				{
 					message: 'Response Validation Error',
@@ -202,6 +206,7 @@ app.post(
 			return ctx.json(
 				{
 					message: 'Request Body Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -245,6 +250,7 @@ app.post(
 
 		const result = getBookResponse.safeParse(createdBook[0]);
 		if (!result.success) {
+			console.error(result.error);
 			return ctx.json(
 				{
 					message: 'Response Validation Error',
@@ -264,6 +270,7 @@ app.get(
 			return ctx.json(
 				{
 					message: 'Path Paramter Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -285,6 +292,7 @@ app.get(
 
 		const result = getBookResponse.safeParse(books[0]);
 		if (!result.success) {
+			console.error(result.error);
 			return ctx.json(
 				{
 					message: 'Response Validation Error',
@@ -304,6 +312,7 @@ app.put(
 			return ctx.json(
 				{
 					message: 'Path Paramter Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -314,6 +323,7 @@ app.put(
 			return ctx.json(
 				{
 					message: 'Request Body Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -360,6 +370,7 @@ app.put(
 
 		const result = updateBookResponse.safeParse(updatedBook[0]);
 		if (!result.success) {
+			console.error(result.error);
 			return ctx.json(
 				{
 					message: 'Response Validation Error',
@@ -378,7 +389,8 @@ app.delete(
 		if (!result.success) {
 			return ctx.json(
 				{
-					message: 'Bad Request',
+					message: 'Path Paramter Validation Error',
+					error: result.error,
 				},
 				400
 			);

--- a/backend/src/api/loan.ts
+++ b/backend/src/api/loan.ts
@@ -1,0 +1,71 @@
+import { loanTable } from '@/drizzle/schema';
+import { zValidator } from '@hono/zod-validator';
+import { and, eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/d1';
+import { Hono } from 'hono';
+import { getLoansQueryParams, getLoansResponse } from '../schema';
+import { isLoggedIn } from '../utils/auth';
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get(
+	'/',
+	zValidator('query', getLoansQueryParams, (result, ctx) => {
+		if (!result.success) {
+			return ctx.json(
+				{
+					message: 'Query Parameter Validation Error',
+				},
+				400
+			);
+		}
+	}),
+	async (ctx) => {
+		const authed = await isLoggedIn(ctx);
+		if (!authed) {
+			return ctx.json(
+				{
+					message: 'Unauthorized',
+				},
+				401
+			);
+		}
+
+		const query = ctx.req.valid('query');
+
+		const page = parseInt(query['page'] ?? '1');
+		const limit = parseInt(query['limit'] ?? '10');
+
+		const db = drizzle(ctx.env.DB);
+
+		const loans = await db
+			.select()
+			.from(loanTable)
+			.where(
+				and(
+					query['userId']
+						? eq(loanTable.userId, parseInt(query['userId']))
+						: undefined,
+					query['bookId']
+						? eq(loanTable.bookId, parseInt(query['bookId']))
+						: undefined
+				)
+			)
+			.limit(limit)
+			.offset((page - 1) * limit);
+
+		const result = getLoansResponse.safeParse(loans);
+		if (!result.success) {
+			return ctx.json(
+				{
+					message: 'Response Validation Error',
+				},
+				500
+			);
+		} else {
+			return ctx.json(result.data);
+		}
+	}
+);
+
+export default app;

--- a/backend/src/api/loan.ts
+++ b/backend/src/api/loan.ts
@@ -1,12 +1,27 @@
-import { loanTable } from '@/drizzle/schema';
+import { bookTable, loanTable, userTable } from '@/drizzle/schema';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq } from 'drizzle-orm';
+import camelCase from 'camelcase';
+import { and, eq, Query } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import { Hono } from 'hono';
-import { getLoansQueryParams, getLoansResponse } from '../schema';
+import {
+	getLoansQueryParams,
+	getLoansResponse,
+	upsertLoansBody,
+	upsertLoansResponse,
+} from '../schema';
 import { isLoggedIn } from '../utils/auth';
 
 const app = new Hono<{ Bindings: Env }>();
+
+// D1に格納されている生の貸出履歴
+interface SnakeLoan {
+	user_id: number;
+	book_id: number;
+	volume: number;
+	created_at?: number;
+	updated_at?: number;
+}
 
 app.get(
 	'/',
@@ -15,6 +30,7 @@ app.get(
 			return ctx.json(
 				{
 					message: 'Query Parameter Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -56,6 +72,7 @@ app.get(
 
 		const result = getLoansResponse.safeParse(loans);
 		if (!result.success) {
+			console.error(result.error);
 			return ctx.json(
 				{
 					message: 'Response Validation Error',
@@ -64,6 +81,163 @@ app.get(
 			);
 		} else {
 			return ctx.json(result.data);
+		}
+	}
+);
+
+app.patch(
+	'/',
+	zValidator('json', upsertLoansBody, async (result, ctx) => {
+		if (!result.success) {
+			return ctx.json(
+				{
+					message: 'Request Body Validation Error',
+					error: result.error,
+				},
+				400
+			);
+		}
+	}),
+	async (ctx) => {
+		const authed = await isLoggedIn(ctx);
+		if (!authed) {
+			return ctx.json(
+				{
+					message: 'Unauthorized',
+				},
+				401
+			);
+		}
+
+		const newLoans = ctx.req.valid('json');
+
+		const db = drizzle(ctx.env.DB);
+		const batch: Query[] = [];
+
+		for (const newLoan of newLoans) {
+			const requestUser = await db
+				.select()
+				.from(userTable)
+				.where(eq(userTable.id, newLoan.userId));
+
+			if (requestUser.length === 0) {
+				// ユーザーが存在しない場合
+				return ctx.json({ userId: newLoan.userId }, 404);
+			}
+
+			// 在庫数を取得する
+			const requestBoook = await db
+				.select()
+				.from(bookTable)
+				.where(eq(bookTable.id, newLoan.bookId));
+
+			if (requestBoook.length === 0) {
+				// 書籍が存在しない場合
+				return ctx.json({ bookId: newLoan.bookId }, 404);
+			}
+
+			if (requestBoook[0].stock < newLoan.volume) {
+				// 貸出数が在庫数を超えている場合
+				return ctx.json(newLoan, 409);
+			}
+
+			// 同じ貸出履歴を検索する
+			const sameLoan = await db
+				.select()
+				.from(loanTable)
+				.where(
+					and(
+						eq(loanTable.userId, newLoan.userId),
+						eq(loanTable.bookId, newLoan.bookId)
+					)
+				);
+			if (0 < sameLoan.length) {
+				// 既に貸出履歴が存在する場合
+				// 更新後の貸出数を計算する
+				const totalVolume = sameLoan[0].volume + newLoan.volume;
+				if (totalVolume < 0) {
+					// 貸出数が負になる場合
+					return ctx.json(newLoan, 409);
+				} else if (totalVolume == 0) {
+					// 貸出数が0になる場合は削除
+					const deleteQuery = db
+						.delete(loanTable)
+						.where(
+							and(
+								eq(loanTable.userId, newLoan.userId),
+								eq(loanTable.bookId, newLoan.bookId)
+							)
+						)
+						.returning()
+						.toSQL();
+					batch.push(deleteQuery);
+				} else if (0 < totalVolume) {
+					// 貸出数が正になる場合は更新
+					const updateQuery = db
+						.update(loanTable)
+						.set({ volume: totalVolume })
+						.where(
+							and(
+								eq(loanTable.userId, newLoan.userId),
+								eq(loanTable.bookId, newLoan.bookId)
+							)
+						)
+						.returning()
+						.toSQL();
+					batch.push(updateQuery);
+				}
+			} else {
+				// 貸出履歴が存在しない場合
+				const createQuery = db
+					.insert(loanTable)
+					.values(newLoan)
+					.returning()
+					.toSQL();
+				batch.push(createQuery);
+			}
+
+			// 貸出数を在庫数から引く
+			const updateQuery = db
+				.update(bookTable)
+				.set({ stock: requestBoook[0].stock - newLoan.volume })
+				.where(eq(bookTable.id, newLoan.bookId))
+				.toSQL();
+			batch.push(updateQuery);
+		}
+
+		const rawDb = ctx.env.DB;
+		const batchResponse: D1Result<SnakeLoan>[] = await rawDb.batch(
+			batch.map((query) => {
+				return rawDb.prepare(query.sql).bind(...query.params);
+			})
+		);
+
+		const upsertedLoans = batchResponse.flatMap((response) => {
+			const results = response.results;
+			// 貸出履歴以外の実行結果は削除する
+			if (results.length === 0) {
+				return [];
+			}
+
+			// プロパティ名をキャメルケースに変換する
+			return Object.fromEntries(
+				Object.entries(results[0]).map(([key, value]) => {
+					return [camelCase(key), value];
+				})
+			);
+		});
+
+		const result = upsertLoansResponse.safeParse(upsertedLoans);
+		if (!result.success) {
+			console.error(result.error);
+			return ctx.json(
+				{
+					message: 'Response Validation Error',
+				},
+				500
+			);
+		} else {
+			return ctx.json(result.data, 200);
 		}
 	}
 );

--- a/backend/src/api/user.ts
+++ b/backend/src/api/user.ts
@@ -26,6 +26,7 @@ app.get(
 			return ctx.json(
 				{
 					message: 'Query Parameter Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -57,6 +58,7 @@ app.get(
 
 		const result = getUsersResponse.safeParse(users);
 		if (!result.success) {
+			console.error(result.error);
 			return ctx.json(
 				{
 					message: 'Response Validation Error',
@@ -76,6 +78,7 @@ app.post(
 			return ctx.json(
 				{
 					message: 'Request Body Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -126,6 +129,7 @@ app.post(
 
 		const result = getUserResponse.safeParse(createdUser[0]);
 		if (!result.success) {
+			console.error(result.error);
 			return ctx.json(
 				{
 					message: 'Response Validation Error',
@@ -145,6 +149,7 @@ app.get(
 			return ctx.json(
 				{
 					message: 'Path Paramter Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -166,6 +171,7 @@ app.get(
 
 		const result = getUserResponse.safeParse(users[0]);
 		if (!result.success) {
+			console.error(result.error);
 			return ctx.json(
 				{
 					message: 'Response Validation Error',
@@ -185,6 +191,7 @@ app.put(
 			return ctx.json(
 				{
 					message: 'Path Paramter Validation Error',
+					error: result.error,
 				},
 				400
 			);
@@ -241,6 +248,7 @@ app.put(
 
 		const result = updateUserResponse.safeParse(updatedBook[0]);
 		if (!result.success) {
+			console.error(result.error);
 			return ctx.json(
 				{
 					message: 'Response Validation Error',
@@ -259,7 +267,8 @@ app.delete(
 		if (!result.success) {
 			return ctx.json(
 				{
-					message: 'Bad Request',
+					message: 'Path Paramter Validation Error',
+					error: result.error,
 				},
 				400
 			);

--- a/backend/src/api/user.ts
+++ b/backend/src/api/user.ts
@@ -184,7 +184,7 @@ app.get(
 	}
 );
 
-app.put(
+app.patch(
 	'/:userId',
 	zValidator('param', updateUserParams, (result, ctx) => {
 		if (!result.success) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,8 +17,7 @@ app.use(
 		origin: (origin: string) => {
 			return origin.includes('localhost')
 				? origin
-				: // TODO: フロントエンドのデプロイ先のURLを指定
-				  'https://frontend.pages.dev';
+				: 'https://kitcc-library-web.pages.dev/';
 		},
 		// リクエストに含めることができるヘッダ
 		allowHeaders: ['Cookie', 'Content-Type'],

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -24,7 +24,7 @@ app.use(
 		allowHeaders: ['Cookie', 'Content-Type'],
 		// 許可するメソッド
 		// OPTIONSはプリフライトリクエストで使われる
-		allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+		allowMethods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
 		// アクセスできるレスポンスのヘッダ
 		exposeHeaders: ['Content-Type', 'Content-Length', 'Set-Cookie'],
 		// 資格情報をフロントエンドのJSに公開するか

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import { logger } from 'hono/logger';
 import { prettyJSON } from 'hono/pretty-json';
 import auth from './api/auth';
 import book from './api/book';
+import loan from './api/loan';
 import user from './api/user';
 
 const app = new Hono();
@@ -35,5 +36,6 @@ app.use(
 app.route('/books', book);
 app.route('/users', user);
 app.route('/auth', auth);
+app.route('/loans', loan);
 
 export default app;

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -288,42 +288,23 @@ export const getLoansResponse = zod.array(getLoansResponseItem)
 
 
 /**
- * @summary 貸出履歴を追加する
- */
-export const createLoansBodyItem = zod.object({
-  "userId": zod.number(),
-  "bookId": zod.number(),
-  "volume": zod.number().min(1)
-})
-export const createLoansBody = zod.array(createLoansBodyItem)
-
-export const createLoansResponse = zod.object({
-  "userId": zod.number(),
-  "bookId": zod.number(),
-  "volume": zod.number(),
-  "createdAt": zod.number().optional(),
-  "updatedAt": zod.number().optional()
-})
-
-
-/**
- * リクエストボディに含まれている情報のみ更新する
  * @summary 貸出履歴を更新する
  */
-export const updateLoansBodyItem = zod.object({
+export const upsertLoansBodyItem = zod.object({
   "userId": zod.number(),
   "bookId": zod.number(),
-  "volume": zod.number().optional()
+  "volume": zod.number()
 })
-export const updateLoansBody = zod.array(updateLoansBodyItem)
+export const upsertLoansBody = zod.array(upsertLoansBodyItem)
 
-export const updateLoansResponse = zod.object({
+export const upsertLoansResponseItem = zod.object({
   "userId": zod.number(),
   "bookId": zod.number(),
   "volume": zod.number(),
   "createdAt": zod.number().optional(),
   "updatedAt": zod.number().optional()
 })
+export const upsertLoansResponse = zod.array(upsertLoansResponseItem)
 
 
 /**

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -278,12 +278,11 @@ export const getLoansQueryParams = zod.object({
 })
 
 export const getLoansResponseItem = zod.object({
-  "id": zod.number(),
   "userId": zod.number(),
   "bookId": zod.number(),
   "volume": zod.number(),
-  "createdAt": zod.string().datetime().optional(),
-  "updatedAt": zod.string().datetime().optional()
+  "createdAt": zod.number().optional(),
+  "updatedAt": zod.number().optional()
 })
 export const getLoansResponse = zod.array(getLoansResponseItem)
 
@@ -299,12 +298,11 @@ export const createLoansBodyItem = zod.object({
 export const createLoansBody = zod.array(createLoansBodyItem)
 
 export const createLoansResponse = zod.object({
-  "id": zod.number(),
   "userId": zod.number(),
   "bookId": zod.number(),
   "volume": zod.number(),
-  "createdAt": zod.string().datetime().optional(),
-  "updatedAt": zod.string().datetime().optional()
+  "createdAt": zod.number().optional(),
+  "updatedAt": zod.number().optional()
 })
 
 
@@ -320,12 +318,11 @@ export const updateLoansBodyItem = zod.object({
 export const updateLoansBody = zod.array(updateLoansBodyItem)
 
 export const updateLoansResponse = zod.object({
-  "id": zod.number(),
   "userId": zod.number(),
   "bookId": zod.number(),
   "volume": zod.number(),
-  "createdAt": zod.string().datetime().optional(),
-  "updatedAt": zod.string().datetime().optional()
+  "createdAt": zod.number().optional(),
+  "updatedAt": zod.number().optional()
 })
 
 

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -78,7 +78,6 @@ export const login = async (ctx: Context, userId: number) => {
 
 export const logout = async (ctx: Context) => {
 	const userIdCookie = getCookie(ctx, 'user_id', 'secure');
-	console.log(userIdCookie);
 	// Cookieが存在しない場合
 	if (userIdCookie === undefined) {
 		return;

--- a/backend/test/api/book.test.ts
+++ b/backend/test/api/book.test.ts
@@ -40,7 +40,7 @@ describe('GET /books/:bookId', () => {
 	});
 });
 
-describe('PUT /books/:bookId', () => {
+describe('PATCH /books/:bookId', () => {
 	const db = drizzle(env.DB);
 	const books = bookFactory.buildList(2);
 
@@ -74,7 +74,7 @@ describe('PUT /books/:bookId', () => {
 		const response = await app.request(
 			`/books/${books[0].id}`,
 			{
-				method: 'PUT',
+				method: 'PATCH',
 				headers: {
 					'Content-Type': 'application/json',
 					Cookie: [
@@ -103,7 +103,7 @@ describe('PUT /books/:bookId', () => {
 				// bookIdに数以外を指定する
 				`/books/id`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [
@@ -126,7 +126,7 @@ describe('PUT /books/:bookId', () => {
 			const response = await app.request(
 				`/books/1`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [
@@ -150,7 +150,7 @@ describe('PUT /books/:bookId', () => {
 			const response = await app.request(
 				`/books/1`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [
@@ -174,7 +174,7 @@ describe('PUT /books/:bookId', () => {
 			const response = await app.request(
 				`/books/1`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [
@@ -198,7 +198,7 @@ describe('PUT /books/:bookId', () => {
 			const response = await app.request(
 				`/books/1`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [
@@ -224,7 +224,7 @@ describe('PUT /books/:bookId', () => {
 			const response = await app.request(
 				`/books/${books[1].id}`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [
@@ -246,7 +246,7 @@ describe('PUT /books/:bookId', () => {
 		const response = await app.request(
 			`/books/1`,
 			{
-				method: 'PUT',
+				method: 'PATCH',
 				headers: {
 					'Content-Type': 'application/json',
 					// Cookieを指定しない
@@ -266,7 +266,7 @@ describe('PUT /books/:bookId', () => {
 				// 存在しないbookIdを指定する
 				`/books/100`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [

--- a/backend/test/api/books.test.ts
+++ b/backend/test/api/books.test.ts
@@ -86,7 +86,13 @@ describe('POST /books', async () => {
 				env
 			);
 
+			// ステータスコード
 			expect(response.status).toBe(201);
+
+			// レスポンスボディ
+			const createdBook = await response.json();
+			const { stock, ...rest } = book;
+			expect(createdBook).toMatchObject(rest);
 
 			// データベースに書籍が登録されていることを確認する
 			const totalBook = await db.select({ count: count() }).from(bookTable);

--- a/backend/test/api/books.test.ts
+++ b/backend/test/api/books.test.ts
@@ -31,7 +31,7 @@ describe('GET /books', () => {
 		expect(books).toHaveLength(limit);
 	});
 
-	it('should return specified book', async () => {
+	it('should return correct book', async () => {
 		const firstBook = { ...books[0], id: 1 };
 
 		const params = new URLSearchParams({ title: firstBook.title }).toString();

--- a/backend/test/api/loans.test.ts
+++ b/backend/test/api/loans.test.ts
@@ -1,0 +1,200 @@
+import {
+	bookTable,
+	InsertLoan,
+	loanTable,
+	SelectLoan,
+	userTable,
+} from '@/drizzle/schema';
+import app from '@/src/index';
+import { env } from 'cloudflare:test';
+import { drizzle } from 'drizzle-orm/d1';
+import { loggedInTest } from '../context/login';
+import { bookFactory } from '../factories/book';
+import { userFactory } from '../factories/user';
+
+describe('GET /loans', () => {
+	const db = drizzle(env.DB);
+
+	const users = userFactory.buildList(3);
+	const books = bookFactory.buildList(3, { stock: 3 });
+	let loans: InsertLoan[] = [];
+
+	beforeAll(async () => {
+		await db.insert(userTable).values(users);
+		await db.insert(bookTable).values(books);
+
+		users.forEach((user, userId) => {
+			books.forEach((book, bookId) => {
+				if (userId !== bookId) {
+					loans.push({
+						userId: userId + 1,
+						bookId: bookId + 1,
+						volume: 1,
+					});
+				}
+			});
+		});
+
+		await db.insert(loanTable).values(loans);
+	});
+
+	afterAll(async () => {
+		await db.delete(userTable);
+		await db.delete(bookTable);
+
+		userFactory.resetSequenceNumber();
+		bookFactory.resetSequenceNumber();
+	});
+
+	loggedInTest(
+		'should return correct loan',
+		async ({ currentUser, sessionToken }) => {
+			const userId = 1;
+			const bookId = 1;
+
+			const params = new URLSearchParams({
+				userId: userId.toString(),
+				bookId: bookId.toString(),
+			}).toString();
+			const response = await app.request(
+				`/loans?${params}`,
+				{
+					headers: {
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+				},
+				env
+			);
+
+			expect(response.status).toBe(200);
+
+			const loans: SelectLoan[] = await response.json();
+			for (const loan of loans) {
+				expect(loan.userId).toBe(userId);
+				expect(loan.bookId).toBe(bookId);
+				expect(loan.volume).toBe(1);
+			}
+		}
+	);
+
+	loggedInTest(
+		'should return correct number of loans',
+		async ({ currentUser, sessionToken }) => {
+			const response = await app.request(
+				'/loans',
+				{
+					headers: {
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+				},
+				env
+			);
+
+			expect(response.status).toBe(200);
+
+			const loans: SelectLoan[] = await response.json();
+			const totalLoans = users.length * (books.length - 1);
+			expect(loans).toHaveLength(totalLoans);
+		}
+	);
+
+	loggedInTest(
+		'should return 400 when userId is not a number',
+		async ({ currentUser, sessionToken }) => {
+			const params = new URLSearchParams({
+				userId: 'userId',
+				bookId: '1',
+			}).toString();
+			const response = await app.request(
+				`/loans?${params}`,
+				{
+					headers: {
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+				},
+				env
+			);
+
+			expect(response.status).toBe(400);
+		}
+	);
+
+	loggedInTest(
+		'should return 400 when bookId is not a number',
+		async ({ currentUser, sessionToken }) => {
+			const params = new URLSearchParams({
+				userId: '1',
+				bookId: 'bookId',
+			}).toString();
+			const response = await app.request(
+				`/loans?${params}`,
+				{
+					headers: {
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+				},
+				env
+			);
+
+			expect(response.status).toBe(400);
+		}
+	);
+
+	loggedInTest(
+		'should return 400 when page is not a number',
+		async ({ currentUser, sessionToken }) => {
+			const response = await app.request(
+				'/loans?page=a',
+				{
+					headers: {
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+				},
+				env
+			);
+
+			expect(response.status).toBe(400);
+		}
+	);
+
+	loggedInTest(
+		'should return 400 when limit is not a number',
+		async ({ currentUser, sessionToken }) => {
+			const response = await app.request(
+				'/loans?limit=a',
+				{
+					headers: {
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+				},
+				env
+			);
+
+			expect(response.status).toBe(400);
+		}
+	);
+
+	it('should return 401 when not logged in', async () => {
+		const response = await app.request('/loans', {}, env);
+
+		expect(response.status).toBe(401);
+	});
+});

--- a/backend/test/api/loans.test.ts
+++ b/backend/test/api/loans.test.ts
@@ -85,7 +85,7 @@ describe('GET /loans', () => {
 		'should return correct number of loans',
 		async ({ currentUser, sessionToken }) => {
 			const response = await app.request(
-				'/loans',
+				'/loans?page=1&limit=10',
 				{
 					headers: {
 						Cookie: [

--- a/backend/test/api/loans.test.ts
+++ b/backend/test/api/loans.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@/drizzle/schema';
 import app from '@/src/index';
 import { env } from 'cloudflare:test';
+import { and, eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import { loggedInTest } from '../context/login';
 import { bookFactory } from '../factories/book';
@@ -197,4 +198,476 @@ describe('GET /loans', () => {
 
 		expect(response.status).toBe(401);
 	});
+});
+
+describe('PATCH /loans', () => {
+	const db = drizzle(env.DB);
+
+	const users = userFactory.buildList(2);
+	const books = bookFactory.buildList(2, { stock: 3 });
+
+	beforeAll(async () => {
+		await db.insert(userTable).values(users);
+		await db.insert(bookTable).values(books);
+		await db.insert(loanTable).values([
+			{
+				userId: 1,
+				bookId: 1,
+				volume: 1,
+			},
+		]);
+	});
+
+	afterAll(async () => {
+		await db.delete(userTable);
+		await db.delete(bookTable);
+		await db.delete(loanTable);
+
+		userFactory.resetSequenceNumber();
+		bookFactory.resetSequenceNumber();
+	});
+
+	loggedInTest(
+		'should create new loan',
+		async ({ currentUser, sessionToken }) => {
+			const newLoan = {
+				userId: currentUser.id,
+				bookId: 1,
+				volume: 1,
+			};
+
+			const response = await app.request(
+				'/loans',
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+					body: JSON.stringify([newLoan]),
+				},
+				env
+			);
+
+			// ステータスコード
+			expect(response.status).toBe(200);
+
+			// レスポンスボディ
+			const createdLoans: SelectLoan[] = await response.json();
+			expect(createdLoans).toHaveLength(1);
+			expect(createdLoans[0].userId).toBe(newLoan.userId);
+			expect(createdLoans[0].bookId).toBe(newLoan.bookId);
+			expect(createdLoans[0].volume).toBe(newLoan.volume);
+
+			// 貸出履歴が作成されているか確認する
+			const createdLoan = await db
+				.select()
+				.from(loanTable)
+				.where(
+					and(
+						eq(loanTable.userId, newLoan.userId!),
+						eq(loanTable.bookId, newLoan.bookId)
+					)
+				);
+			expect(createdLoan[0].volume).toBe(newLoan.volume);
+
+			// 書籍の在庫数が減っているか確認する
+			const updatedBook = await db
+				.select()
+				.from(bookTable)
+				.where(eq(bookTable.id, newLoan.bookId));
+			expect(updatedBook[0].stock).toBe(books[0].stock! - 1);
+		}
+	);
+
+	loggedInTest('should update loan', async ({ currentUser, sessionToken }) => {
+		const newLoan = {
+			userId: 1,
+			bookId: 1,
+			volume: 1,
+		};
+
+		const response = await app.request(
+			'/loans',
+			{
+				method: 'PATCH',
+				headers: {
+					'Content-Type': 'application/json',
+					Cookie: [
+						`__Secure-user_id=${currentUser.id}`,
+						`__Secure-session_token=${sessionToken}`,
+					].join('; '),
+				},
+				body: JSON.stringify([newLoan]),
+			},
+			env
+		);
+
+		// ステータスコード
+		expect(response.status).toBe(200);
+
+		// レスポンスボディ
+		const createdLoans: SelectLoan[] = await response.json();
+		expect(createdLoans[0].userId).toBe(newLoan.userId);
+		expect(createdLoans[0].bookId).toBe(newLoan.bookId);
+		expect(createdLoans[0].volume).toBe(newLoan.volume + 1);
+
+		// 貸出履歴が更新されているか確認する
+		const updatedLoan = await db
+			.select()
+			.from(loanTable)
+			.where(
+				and(
+					eq(loanTable.userId, newLoan.userId),
+					eq(loanTable.bookId, newLoan.bookId)
+				)
+			);
+		expect(updatedLoan[0].volume).toBe(newLoan.volume + 1);
+
+		// 書籍の在庫数が減っているか確認する
+		const updatedBook = await db
+			.select()
+			.from(bookTable)
+			.where(eq(bookTable.id, newLoan.bookId));
+		expect(updatedBook[0].stock).toBe(books[0].stock! - 1);
+	});
+
+	loggedInTest(
+		'should return 400 when userId is missing',
+		async ({ currentUser, sessionToken }) => {
+			const newLoan = {
+				// userIdを指定しない
+				bookId: 1,
+				volume: 1,
+			};
+
+			const response = await app.request(
+				'/loans',
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+					body: JSON.stringify([newLoan]),
+				},
+				env
+			);
+
+			expect(response.status).toBe(400);
+		}
+	);
+
+	loggedInTest(
+		'should return 400 when userId is not a number',
+		async ({ currentUser, sessionToken }) => {
+			const newLoan = {
+				// userIdに数以外を指定する
+				userId: 'userId',
+				bookId: 1,
+				volume: 1,
+			};
+
+			const response = await app.request(
+				'/loans',
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+					body: JSON.stringify([newLoan]),
+				},
+				env
+			);
+
+			expect(response.status).toBe(400);
+		}
+	);
+
+	loggedInTest(
+		'should return 404 when user does not exist',
+		async ({ currentUser, sessionToken }) => {
+			const newLoan = {
+				// 存在しないユーザを指定する
+				userId: 100,
+				bookId: 1,
+				volume: 1,
+			};
+
+			const response = await app.request(
+				'/loans',
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+					body: JSON.stringify([newLoan]),
+				},
+				env
+			);
+
+			expect(response.status).toBe(404);
+
+			const body: { userId: number } = await response.json();
+			expect(body.userId).toBe(100);
+		}
+	);
+
+	loggedInTest(
+		'should return 400 when bookId is missing',
+		async ({ currentUser, sessionToken }) => {
+			const newLoan = {
+				userId: 1,
+				// bookIdを指定しない
+				volume: 1,
+			};
+
+			const response = await app.request(
+				'/loans',
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+					body: JSON.stringify([newLoan]),
+				},
+				env
+			);
+
+			expect(response.status).toBe(400);
+		}
+	);
+
+	loggedInTest(
+		'should return 400 when bookId is not a number',
+		async ({ currentUser, sessionToken }) => {
+			const newLoan = {
+				userId: 1,
+				// bookIdに数以外を指定する
+				bookId: 'bookId',
+				volume: 1,
+			};
+
+			const response = await app.request(
+				'/loans',
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+					body: JSON.stringify([newLoan]),
+				},
+				env
+			);
+
+			expect(response.status).toBe(400);
+		}
+	);
+
+	loggedInTest(
+		'should return 404 when book does not exist',
+		async ({ currentUser, sessionToken }) => {
+			const newLoan = {
+				userId: 1,
+				// 存在しない書籍を指定する
+				bookId: 100,
+				volume: 1,
+			};
+
+			const response = await app.request(
+				'/loans',
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+					body: JSON.stringify([newLoan]),
+				},
+				env
+			);
+
+			expect(response.status).toBe(404);
+
+			const body: { bookId: number } = await response.json();
+			expect(body.bookId).toBe(100);
+		}
+	);
+
+	loggedInTest(
+		'should return 400 when volume is missing',
+		async ({ currentUser, sessionToken }) => {
+			const newLoan = {
+				userId: 1,
+				bookId: 1,
+				// volumeを指定しない
+			};
+
+			const response = await app.request(
+				'/loans',
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+					body: JSON.stringify([newLoan]),
+				},
+				env
+			);
+
+			expect(response.status).toBe(400);
+		}
+	);
+
+	loggedInTest(
+		'should return 400 when volume is not a number',
+		async ({ currentUser, sessionToken }) => {
+			const newLoan = {
+				userId: 1,
+				bookId: 1,
+				// volumeに数以外を指定する
+				volume: 'volume',
+			};
+
+			const response = await app.request(
+				'/loans',
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+					body: JSON.stringify([newLoan]),
+				},
+				env
+			);
+
+			expect(response.status).toBe(400);
+		}
+	);
+
+	it('should return 401 when not logged in', async () => {
+		const newLoan = {
+			userId: 1,
+			bookId: 1,
+			volume: 1,
+		};
+
+		const response = await app.request(
+			'/loans',
+			{
+				method: 'PATCH',
+				headers: {
+					'Content-Type': 'application/json',
+					// Cookieを指定しない
+				},
+				body: JSON.stringify([newLoan]),
+			},
+			env
+		);
+
+		expect(response.status).toBe(401);
+	});
+
+	loggedInTest(
+		'should return 400 when volume is lagger than stock',
+		async ({ currentUser, sessionToken }) => {
+			const newLoan = {
+				userId: 1,
+				bookId: 1,
+				// 在庫数より多い冊数を指定する
+				volume: 100,
+			};
+
+			const response = await app.request(
+				'/loans',
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+					body: JSON.stringify([newLoan]),
+				},
+				env
+			);
+
+			expect(response.status).toBe(409);
+
+			const body: SelectLoan = await response.json();
+			expect(body.userId).toBe(newLoan.userId);
+			expect(body.bookId).toBe(newLoan.bookId);
+			expect(body.volume).toBe(newLoan.volume);
+		}
+	);
+
+	loggedInTest(
+		'should return 400 when total volume is negative',
+		async ({ currentUser, sessionToken }) => {
+			const newLoan = {
+				userId: 1,
+				bookId: 1,
+				// 貸出数よりも多い冊数を指定する
+				volume: -100,
+			};
+
+			const response = await app.request(
+				'/loans',
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+					body: JSON.stringify([newLoan]),
+				},
+				env
+			);
+
+			expect(response.status).toBe(409);
+
+			const body: SelectLoan = await response.json();
+			expect(body.userId).toBe(newLoan.userId);
+			expect(body.bookId).toBe(newLoan.bookId);
+			expect(body.volume).toBe(newLoan.volume);
+		}
+	);
 });

--- a/backend/test/api/user.test.ts
+++ b/backend/test/api/user.test.ts
@@ -42,7 +42,7 @@ describe('GET /users/:userId', () => {
 	});
 });
 
-describe('PUT /users/:userId', () => {
+describe('PATCH /users/:userId', () => {
 	const db = drizzle(env.DB);
 	const users = userFactory.buildList(2);
 
@@ -69,7 +69,7 @@ describe('PUT /users/:userId', () => {
 		const response = await app.request(
 			`/users/${users[0].id}`,
 			{
-				method: 'PUT',
+				method: 'PATCH',
 				headers: {
 					'Content-Type': 'application/json',
 					Cookie: [
@@ -100,7 +100,7 @@ describe('PUT /users/:userId', () => {
 				// userIdに数字以外を指定する
 				`/users/id`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [
@@ -123,7 +123,7 @@ describe('PUT /users/:userId', () => {
 			const response = await app.request(
 				`/users/1`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [
@@ -147,7 +147,7 @@ describe('PUT /users/:userId', () => {
 			const response = await app.request(
 				`/users/1`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [
@@ -178,7 +178,7 @@ describe('PUT /users/:userId', () => {
 				const response = await app.request(
 					`/users/1`,
 					{
-						method: 'PUT',
+						method: 'PATCH',
 						headers: {
 							'Content-Type': 'application/json',
 							Cookie: [
@@ -205,7 +205,7 @@ describe('PUT /users/:userId', () => {
 			const response = await app.request(
 				`/users/${users[1].id}`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [
@@ -228,7 +228,7 @@ describe('PUT /users/:userId', () => {
 		const response = await app.request(
 			`/users/1`,
 			{
-				method: 'PUT',
+				method: 'PATCH',
 				body: JSON.stringify({ name: '比企谷八幡' }),
 			}
 		);
@@ -243,7 +243,7 @@ describe('PUT /users/:userId', () => {
 				// 存在しないuserIdを指定する
 				`/users/100`,
 				{
-					method: 'PUT',
+					method: 'PATCH',
 					headers: {
 						'Content-Type': 'application/json',
 						Cookie: [

--- a/backend/test/api/users.test.ts
+++ b/backend/test/api/users.test.ts
@@ -31,7 +31,7 @@ describe('GET /users', () => {
 		expect(users).toHaveLength(limit);
 	});
 
-	it('should return specified user', async () => {
+	it('should return correct user', async () => {
 		const firstUser = { ...users[0], id: 1, sessionToken: null };
 
 		const params = new URLSearchParams({ email: firstUser.email }).toString();

--- a/backend/test/api/users.test.ts
+++ b/backend/test/api/users.test.ts
@@ -1,4 +1,4 @@
-import { userTable } from '@/drizzle/schema';
+import { SelectUser, userTable } from '@/drizzle/schema';
 import app from '@/src/index';
 import { env } from 'cloudflare:test';
 import { count } from 'drizzle-orm';
@@ -90,7 +90,13 @@ describe('POST /users', () => {
 				env
 			);
 
+			// ステータスコード
 			expect(response.status).toBe(201);
+
+			// レスポンスボディ
+			const createdUser: SelectUser = await response.json();
+			const { passwordDigest, ...rest } = newUser;
+			expect(createdUser).toMatchObject(rest);
 
 			// データベースにユーザが登録されていることを確認する
 			const totalUser = await db.select({ count: count() }).from(userTable);

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -47,3 +47,20 @@ await db
     `
 	)
 	.run();
+
+await db
+	.prepare(
+		`
+    CREATE TABLE loans (
+      book_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      volume INTEGER DEFAULT 1 NOT NULL,
+      created_at TEXT DEFAULT (datetime(current_timestamp, '+9 hours')) NOT NULL,
+      updated_at TEXT DEFAULT (datetime(current_timestamp, '+9 hours')) NOT NULL,
+      PRIMARY KEY(book_id, user_id),
+      FOREIGN KEY (book_id) REFERENCES books(id) ON UPDATE no action ON DELETE cascade,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE no action ON DELETE cascade
+    );
+    `
+	)
+	.run();

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -52,14 +52,14 @@ await db
 	.prepare(
 		`
     CREATE TABLE loans (
-      book_id INTEGER NOT NULL,
       user_id INTEGER NOT NULL,
+      book_id INTEGER NOT NULL,
       volume INTEGER DEFAULT 1 NOT NULL,
-      created_at TEXT DEFAULT (datetime(current_timestamp, '+9 hours')) NOT NULL,
-      updated_at TEXT DEFAULT (datetime(current_timestamp, '+9 hours')) NOT NULL,
-      PRIMARY KEY(book_id, user_id),
-      FOREIGN KEY (book_id) REFERENCES books(id) ON UPDATE no action ON DELETE cascade,
-      FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE no action ON DELETE cascade
+      created_at INTEGER DEFAULT (unixepoch()) NOT NULL,
+      updated_at INTEGER DEFAULT (unixepoch()) NOT NULL,
+      PRIMARY KEY(user_id, book_id),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE NO ACTION ON DELETE CASCADE,
+      FOREIGN KEY (book_id) REFERENCES books(id) ON UPDATE NO ACTION ON DELETE CASCADE
     );
     `
 	)

--- a/orval.config.js
+++ b/orval.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  library: {
+  zod: {
     input: {
       target: './api/bundle.yml',
     },


### PR DESCRIPTION
- Close #12 
- Close #34

## 確認した方法

- `npm run dev`でローカルサーバを起動
- Thunder Clinetでリクエストを送信する
  - Cookieに user_id と session_token を設定するのを忘れない
- 所望のレスポンスが帰ってくるか確認する


## やったこと

- 貸出履歴のスキーマを定義した 33c7b3afaef9973f4ce0dac696d623e826a10416
- マイグレーションファイルを生成した faf25580b76eea383cce2b21f0fc1010f58fc3e1
- サンプルデータを挿入するクエリを書いた e17f569706ce19ba5ddcb60403d4945de5620c99
- GET /loans を実装した 09cecc7a9d227eba3af7e9b1ab298775e1ade9fe
- POST /loans を実装した 157e95eba6e879cf273b4986591730476fb49ebb
- PUT /books をPATCHに変更した 3d17e566106dbd6ba3e55decf5440574934ed644
- PUT /books をPATCHに変更した 780d7c896f265400c324a48546fa06932ad1a546
- CORSでPATCHメソッドを許可した 865659acc8e39b44a0b418db3119d8a8cd898675
- CORSでフロントエンドのデプロイ先を指定した c5cdf5944ebb8094d30932c0a263c3fba0db737f

## 自動生成したコード

- `src/schema.ts`
- `drizzle/migrations`