### PR TITLE
fix:frontend wrangler name

### DIFF
--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -1,5 +1,5 @@
 #:schema node_modules/wrangler/config-schema.json
-name = "frontend"
+name = "kitcc-library-web"
 compatibility_date = "2024-10-04"
 pages_build_output_dir = "./build/client"
 


### PR DESCRIPTION
<!-- Closeするissue名 -->
- close 

## 確認した方法


## スクリーンショット


## やったこと

- やったこと (コミットのハッシュ)
- frontendのcloudflareのサービス名を"kitcc-library-web"にした。

## 自動生成したコード

- ファイル名