### PR TITLE
ページネーションのAPIのレスポンスに総ページ数を追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 OpenAPIからzodのスキーマを生成する
 ```
-npx orval
+npx orval [--config <config.js>]
 ```
 
 ## Prism

--- a/api/bundle.yml
+++ b/api/bundle.yml
@@ -79,9 +79,15 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Book'
+                type: object
+                properties:
+                  totalPage:
+                    description: 総ページ数
+                    type: integer
+                  books:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Book'
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
@@ -137,9 +143,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                message: Created
+                $ref: '#/components/schemas/Book'
+              examples:
+                book:
+                  $ref: '#/components/examples/book'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -177,7 +184,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-    put:
+    patch:
       tags:
         - book
       operationId: updateBook
@@ -325,34 +332,45 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    title:
-                      type: string
-                    authors:
-                      type: array
-                      items:
-                        type: string
-                    publisher:
-                      type: string
-                    thumbnail:
-                      type: string
-                    isbn:
-                      type: string
-                  required:
-                    - title
-                    - authors
+                type: object
+                properties:
+                  totalPage:
+                    description: 総ページ数
+                    type: integer
+                  books:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        title:
+                          type: string
+                        authors:
+                          type: array
+                          items:
+                            type: string
+                        publisher:
+                          type: string
+                        thumbnail:
+                          type: string
+                        isbn:
+                          type: string
+                      required:
+                        - title
+                        - authors
+                required:
+                  - totalPage
+                  - books
               example:
-                - title: 計算機プログラムの構造と解釈
-                  authors:
-                    - Harold Abelson
-                    - Gerald Jay Sussman
-                    - Julie Sussman
-                  publisher: 翔泳社
-                  thumbnail: http://books.google.com/books/content?id=LlH-oAEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api
-                  isbn: '9784798135984'
+                totalPage: 3
+                books:
+                  - title: 計算機プログラムの構造と解釈
+                    authors:
+                      - Harold Abelson
+                      - Gerald Jay Sussman
+                      - Julie Sussman
+                    publisher: 翔泳社
+                    thumbnail: http://books.google.com/books/content?id=LlH-oAEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api
+                    isbn: '9784798135984'
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
@@ -448,12 +466,10 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-              example:
-                message: Created
+                $ref: '#/components/schemas/User'
+              examples:
+                user:
+                  $ref: '#/components/examples/user'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -499,7 +515,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-    put:
+    patch:
       tags:
         - user
       operationId: updateUser
@@ -650,11 +666,11 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
-    post:
+    patch:
       tags:
         - loan
-      operationId: createLoans
-      summary: 貸出履歴を追加する
+      operationId: upsertLoans
+      summary: 貸出履歴を更新する
       security:
         - CookieAuth: []
       requestBody:
@@ -672,7 +688,6 @@ paths:
                     type: integer
                   volume:
                     type: integer
-                    minimum: 1
                 required:
                   - userId
                   - bookId
@@ -683,28 +698,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Loan'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Loan'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    put:
-      tags:
-        - loan
-      operationId: updateLoans
-      summary: 貸出履歴を更新する
-      description: リクエストボディに含まれている情報のみ更新する
-      security:
-        - CookieAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
+        '404':
+          description: ユーザーまたは書籍が存在しない
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  userId:
+                    type: integer
+                  bookId:
+                    type: integer
+                required:
+                  - userId
+                  - bookId
+        '409':
+          description: |
+            貸出数が在庫数を超えている． 返却数が貸出数を超えている．
+          content:
+            application/json:
+              schema:
+                description: 貸出数が在庫数を超えているリクエスト
                 type: object
                 properties:
                   userId:
@@ -716,17 +737,7 @@ paths:
                 required:
                   - userId
                   - bookId
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Loan'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
+                  - volume
         '500':
           $ref: '#/components/responses/InternalServerError'
   /auth:
@@ -776,6 +787,8 @@ paths:
                   $ref: '#/components/examples/user'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -871,8 +884,6 @@ components:
     Loan:
       type: object
       properties:
-        id:
-          type: integer
         userId:
           type: integer
         bookId:
@@ -880,13 +891,12 @@ components:
         volume:
           type: integer
         createdAt:
-          type: string
-          format: date-time
+          type: integer
+          description: レコードが作成されたUNIX時間
         updatedAt:
-          type: string
-          format: date-time
+          type: integer
+          description: レコードが最後に更新されたUNIX時間
       required:
-        - id
         - userId
         - bookId
         - volume

--- a/api/bundle.yml
+++ b/api/bundle.yml
@@ -668,9 +668,17 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Loan'
+                type: object
+                properties:
+                  totalPage:
+                    type: integer
+                  loans:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Loan'
+                required:
+                  - totalPage
+                  - loans
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':

--- a/api/bundle.yml
+++ b/api/bundle.yml
@@ -88,6 +88,9 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Book'
+                required:
+                  - totalPage
+                  - books
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
@@ -421,9 +424,17 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/User'
+                type: object
+                properties:
+                  totalPage:
+                    type: integer
+                  users:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/User'
+                required:
+                  - totalPage
+                  - users
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':

--- a/api/paths/book.yml
+++ b/api/paths/book.yml
@@ -65,6 +65,9 @@ books:
                   type: array
                   items:
                     $ref: "../components/schemas/Book.yml"
+              required:
+                - totalPage
+                - books
       '400':
         $ref: "../components/responses/4xx.yml#/BadRequest"
       '500':

--- a/api/paths/book.yml
+++ b/api/paths/book.yml
@@ -315,34 +315,45 @@ search:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: object
-                properties:
-                  title:
-                    type: string
-                  authors:
-                    type: array
-                    items:
-                      type: string
-                  publisher:
-                    type: string
-                  thumbnail:
-                    type: string
-                  isbn:
-                    type: string
-                required:
-                  - title
-                  - authors
+              type: object
+              properties:
+                totalPage:
+                  description: 総ページ数
+                  type: integer
+                books:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      title:
+                        type: string
+                      authors:
+                        type: array
+                        items:
+                          type: string
+                      publisher:
+                        type: string
+                      thumbnail:
+                        type: string
+                      isbn:
+                        type: string
+                    required:
+                      - title
+                      - authors
+              required:
+                - totalPage
+                - books
             example:
-              - title: "計算機プログラムの構造と解釈"
-                authors:
-                  - "Harold Abelson"
-                  - "Gerald Jay Sussman"
-                  - "Julie Sussman"
-                publisher: "翔泳社"
-                thumbnail: "http://books.google.com/books/content?id=LlH-oAEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
-                isbn: "9784798135984"
+              totalPage: 3
+              books:
+                - title: "計算機プログラムの構造と解釈"
+                  authors:
+                    - "Harold Abelson"
+                    - "Gerald Jay Sussman"
+                    - "Julie Sussman"
+                  publisher: "翔泳社"
+                  thumbnail: "http://books.google.com/books/content?id=LlH-oAEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
+                  isbn: "9784798135984"
       '400':
         $ref: "../components/responses/4xx.yml#/BadRequest"
       '500':

--- a/api/paths/book.yml
+++ b/api/paths/book.yml
@@ -56,9 +56,15 @@ books:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: "../components/schemas/Book.yml"
+              type: object
+              properties:
+                totalPage:
+                  description: 総ページ数
+                  type: integer
+                books:
+                  type: array
+                  items:
+                    $ref: "../components/schemas/Book.yml"
       '400':
         $ref: "../components/responses/4xx.yml#/BadRequest"
       '500':

--- a/api/paths/loan.yml
+++ b/api/paths/loan.yml
@@ -46,9 +46,17 @@ loans:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: "../components/schemas/Loan.yml"
+              type: object
+              properties:
+                totalPage:
+                  type: integer
+                loans:
+                  type: array
+                  items:
+                    $ref: "../components/schemas/Loan.yml"
+              required:
+                - totalPage
+                - loans
       '400':
         $ref: "../components/responses/4xx.yml#/BadRequest"
       '401':

--- a/api/paths/user.yml
+++ b/api/paths/user.yml
@@ -44,9 +44,17 @@ users:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: "../components/schemas/User.yml"
+              type: object
+              properties:
+                totalPage:
+                  type: integer
+                users:
+                  type: array
+                  items:
+                    $ref: "../components/schemas/User.yml"
+              required:
+                - totalPage
+                - users
       '400':
         $ref: "../components/responses/4xx.yml#/BadRequest"
       '500':

--- a/backend/src/api/book.ts
+++ b/backend/src/api/book.ts
@@ -22,6 +22,7 @@ const app = new Hono<{ Bindings: Env }>();
 
 // Google Books APIのレスポンス
 interface GBAResult {
+	totalItems: number;
 	items?: [
 		{
 			volumeInfo: {
@@ -92,6 +93,9 @@ app.get(
 		const response = await fetch(`https://www.googleapis.com/books/v1/volumes?${params}`);
 		const body: GBAResult = await response.json();
 
+		// 総ページ数を計算する
+		const totalPage = Math.ceil(body.totalItems / limit);
+
 		// ヒットした書籍を格納する配列
 		const hitBooks: GoogleBook[] = [];
 
@@ -126,7 +130,8 @@ app.get(
 			}
 		}
 
-		const result = searchBooksResponse.safeParse(hitBooks);
+		// prettier-ignore
+		const result = searchBooksResponse.safeParse({ totalPage: totalPage, books: hitBooks });
 		if (!result.success) {
 			console.error(result.error);
 			return ctx.json(

--- a/backend/src/api/book.ts
+++ b/backend/src/api/book.ts
@@ -188,14 +188,17 @@ app.get(
 			)
 			.orderBy(asc(bookTable.id));
 
+		// 総ページ数を計算する
 		const totalPage = Math.ceil(hitBooks.length / limit);
 		if (totalPage < page) {
 			return ctx.json({ message: `Page ${page} is out of range` }, 400);
 		}
 
+		// 指定されたページの書籍を取得する
 		const slicedBooks = hitBooks.slice((page - 1) * limit, page * limit);
 
-		const result = getBooksResponse.safeParse(slicedBooks);
+		// prettier-ignore
+		const result = getBooksResponse.safeParse({ totalPage: totalPage, books: slicedBooks });
 		if (!result.success) {
 			console.error(result.error);
 			return ctx.json(
@@ -205,10 +208,7 @@ app.get(
 				500
 			);
 		} else {
-			return ctx.json({
-				totalPage: totalPage,
-				books: result.data,
-			});
+			return ctx.json(result.data);
 		}
 	}
 );

--- a/backend/src/api/book.ts
+++ b/backend/src/api/book.ts
@@ -166,6 +166,7 @@ app.get(
 		const limit = parseInt(query['limit'] ?? '10');
 
 		const db = drizzle(ctx.env.DB);
+		// 書籍を検索する
 		const hitBooks: SelectBook[] = await db
 			.select()
 			.from(bookTable)

--- a/backend/src/api/user.ts
+++ b/backend/src/api/user.ts
@@ -1,6 +1,6 @@
 import { SelectUser, userTable } from '@/drizzle/schema';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq, like } from 'drizzle-orm';
+import { and, asc, eq, like } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import { Hono } from 'hono';
 import {
@@ -53,7 +53,8 @@ app.get(
 						? eq(userTable.email, query['email'])
 						: undefined
 				)
-			);
+			)
+			.orderBy(asc(userTable.id));
 
 		// 総ページ数を計算する
 		const totalPage = Math.ceil(hitUsers.length / limit);

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -27,19 +27,21 @@ export const getBooksQueryParams = zod.object({
   "isbn": zod.string().regex(getBooksQueryIsbnRegExp).optional()
 })
 
-export const getBooksResponseIsbnRegExp = new RegExp('^\\d{10}(\\d{3})?$');
+export const getBooksResponseBooksItemIsbnRegExp = new RegExp('^\\d{10}(\\d{3})?$');
 
 
-export const getBooksResponseItem = zod.object({
+export const getBooksResponse = zod.object({
+  "totalPage": zod.number().optional(),
+  "books": zod.array(zod.object({
   "id": zod.number(),
   "title": zod.string(),
   "authors": zod.array(zod.string()),
   "publisher": zod.string(),
   "thumbnail": zod.string().url().optional(),
-  "isbn": zod.string().regex(getBooksResponseIsbnRegExp),
+  "isbn": zod.string().regex(getBooksResponseBooksItemIsbnRegExp),
   "stock": zod.number()
+})).optional()
 })
-export const getBooksResponse = zod.array(getBooksResponseItem)
 
 
 /**
@@ -149,14 +151,16 @@ export const searchBooksQueryParams = zod.object({
   "isbn": zod.string().regex(searchBooksQueryIsbnRegExp).optional()
 })
 
-export const searchBooksResponseItem = zod.object({
+export const searchBooksResponse = zod.object({
+  "totalPage": zod.number(),
+  "books": zod.array(zod.object({
   "title": zod.string(),
   "authors": zod.array(zod.string()),
   "publisher": zod.string().optional(),
   "thumbnail": zod.string().optional(),
   "isbn": zod.string().optional()
+}))
 })
-export const searchBooksResponse = zod.array(searchBooksResponseItem)
 
 
 /**

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -31,7 +31,7 @@ export const getBooksResponseBooksItemIsbnRegExp = new RegExp('^\\d{10}(\\d{3})?
 
 
 export const getBooksResponse = zod.object({
-  "totalPage": zod.number().optional(),
+  "totalPage": zod.number(),
   "books": zod.array(zod.object({
   "id": zod.number(),
   "title": zod.string(),
@@ -40,7 +40,7 @@ export const getBooksResponse = zod.object({
   "thumbnail": zod.string().url().optional(),
   "isbn": zod.string().regex(getBooksResponseBooksItemIsbnRegExp),
   "stock": zod.number()
-})).optional()
+}))
 })
 
 
@@ -178,14 +178,16 @@ export const getUsersQueryParams = zod.object({
   "email": zod.string().email().optional()
 })
 
-export const getUsersResponseItem = zod.object({
+export const getUsersResponse = zod.object({
+  "totalPage": zod.number(),
+  "users": zod.array(zod.object({
   "id": zod.number(),
   "name": zod.string(),
   "email": zod.string().email(),
   "passwordDigest": zod.string(),
   "sessionToken": zod.string().nullish()
+}))
 })
-export const getUsersResponse = zod.array(getUsersResponseItem)
 
 
 /**

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -283,14 +283,16 @@ export const getLoansQueryParams = zod.object({
   "limit": zod.string().min(1).regex(getLoansQueryLimitRegExp).optional()
 })
 
-export const getLoansResponseItem = zod.object({
+export const getLoansResponse = zod.object({
+  "totalPage": zod.number(),
+  "loans": zod.array(zod.object({
   "userId": zod.number(),
   "bookId": zod.number(),
   "volume": zod.number(),
   "createdAt": zod.number().optional(),
   "updatedAt": zod.number().optional()
+}))
 })
-export const getLoansResponse = zod.array(getLoansResponseItem)
 
 
 /**

--- a/backend/test/api/books.test.ts
+++ b/backend/test/api/books.test.ts
@@ -53,16 +53,14 @@ describe('GET /books', () => {
 
 	it('should return 400 when page is not a number', async () => {
 		// pageに数字以外を指定する
-		const params = new URLSearchParams({ page: 'a' }).toString();
-		const response = await app.request(`/books?${params}`, {}, env);
+		const response = await app.request('/books?page=a', {}, env);
 
 		expect(response.status).toBe(400);
 	});
 
 	it('should return 400 when limit is not a number', async () => {
 		// limitに数字以外を指定する
-		const params = new URLSearchParams({ limit: 'a' }).toString();
-		const response = await app.request(`/books?${params}`, {}, env);
+		const response = await app.request('/books?limit=a', {}, env);
 
 		expect(response.status).toBe(400);
 	});

--- a/backend/test/api/books.test.ts
+++ b/backend/test/api/books.test.ts
@@ -48,7 +48,7 @@ describe('GET /books', () => {
 
 		const body: GetBooksResponse = await response.json();
 		expect(body.totalPage).toBe(1);
-		expect(body.books[0]).toMatchObject(firstBook);
+		expect(body.books).toContainEqual(firstBook);
 	});
 
 	it('should return 400 when page is not a number', async () => {

--- a/backend/test/api/books.test.ts
+++ b/backend/test/api/books.test.ts
@@ -1,10 +1,15 @@
-import { bookTable } from '@/drizzle/schema';
+import { bookTable, SelectBook } from '@/drizzle/schema';
 import app from '@/src/index';
 import { env } from 'cloudflare:test';
 import { count, eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import { loggedInTest } from '../context/login';
 import { bookFactory } from '../factories/book';
+
+interface GetBooksResponse {
+	totalPage: number;
+	books: SelectBook[];
+}
 
 describe('GET /books', () => {
 	const db = drizzle(env.DB);
@@ -25,10 +30,12 @@ describe('GET /books', () => {
 		// prettier-ignore
 		const params = new URLSearchParams({ page: '1', limit: limit.toString() }).toString();
 		const response = await app.request(`/books?${params}`, {}, env);
-		const books = await response.json();
 
 		expect(response.status).toBe(200);
-		expect(books).toHaveLength(limit);
+
+		const body: GetBooksResponse = await response.json();
+		expect(body.totalPage).toBe(2);
+		expect(body.books).toHaveLength(limit);
 	});
 
 	it('should return correct book', async () => {
@@ -36,10 +43,12 @@ describe('GET /books', () => {
 
 		const params = new URLSearchParams({ title: firstBook.title }).toString();
 		const response = await app.request(`/books?${params}`, {}, env);
-		const result = await response.json();
 
 		expect(response.status).toBe(200);
-		expect(result).toContainEqual(firstBook);
+
+		const body: GetBooksResponse = await response.json();
+		expect(body.totalPage).toBe(1);
+		expect(body.books[0]).toMatchObject(firstBook);
 	});
 
 	it('should return 400 when page is not a number', async () => {

--- a/backend/test/api/users.test.ts
+++ b/backend/test/api/users.test.ts
@@ -48,7 +48,7 @@ describe('GET /users', () => {
 
 		const body: GetUsersResponse = await response.json();
 		expect(body.totalPage).toBe(1);
-		expect(body.users[0]).toMatchObject(firstUser);
+		expect(body.users).toContainEqual(firstUser);
 	});
 
 	it('should return 400 when page is not a number', async () => {

--- a/backend/test/api/users.test.ts
+++ b/backend/test/api/users.test.ts
@@ -53,16 +53,14 @@ describe('GET /users', () => {
 
 	it('should return 400 when page is not a number', async () => {
 		// pageに数字以外を指定する
-		const params = new URLSearchParams({ page: 'a' }).toString();
-		const response = await app.request(`/users?${params}`, {}, env);
+		const response = await app.request(`/users?page=a`, {}, env);
 
 		expect(response.status).toBe(400);
 	});
 
 	it('should return 400 when limit is not a number', async () => {
 		// limitに数字以外を指定する
-		const params = new URLSearchParams({ limit: 'a' }).toString();
-		const response = await app.request(`/users?${params}`, {}, env);
+		const response = await app.request('/users?limit=a', {}, env);
 
 		expect(response.status).toBe(400);
 	});

--- a/orval.config.dev.js
+++ b/orval.config.dev.js
@@ -1,5 +1,5 @@
 module.exports = {
-  frontend: {
+  client: {
     input: {
       target: './api/bundle.yml',
     },
@@ -7,7 +7,7 @@ module.exports = {
       client: 'react-query',
       httpClient: 'fetch',
       mode: 'split',
-      target: './frontend/orval',
+      target: './frontend/orval/client.ts',
       baseUrl: 'http://localhost:8787' // build時には削除
     },
   },

--- a/orval.config.js
+++ b/orval.config.js
@@ -1,4 +1,15 @@
 module.exports = {
+  client: {
+    input: {
+      target: './api/bundle.yml',
+    },
+    output: {
+      client: 'react-query',
+      httpClient: 'fetch',
+      mode: 'split',
+      target: './frontend/orval/client.ts',
+    },
+  },
   zod: {
     input: {
       target: './api/bundle.yml',
@@ -7,17 +18,6 @@ module.exports = {
       client: 'zod',
       mode: 'single',
       target: './backend/src/schema.ts',
-    },
-  },
-  frontend: {
-    input: {
-      target: './api/bundle.yml',
-    },
-    output: {
-      client: 'react-query',
-      httpClient: 'fetch',
-      mode: 'split',
-      target: './frontend/orval',
     },
   },
 };


### PR DESCRIPTION
<!-- Closeするissue名 -->
- close #41 

## 確認した方法
- `npm run dev`でローカルサーバを起動する
- Thunder Clientでリクエストを送る
- 期待したリクエストが返ってくることを確認する


## やったこと

- やったこと (コミットのハッシュ)
- GET /books に `maxPage` を追加した 5de5c2fa2bed664d162605143f0224dbc7cd2f7a
- GET /users に `maxPage` を追加した 06f5bfa4dbaf9100de19bba7cccad71e82850ff3
- GET /loans に `maxPage` を追加した beac015275625e5423324132be48f1209a0c3c0a
- Orvalが出力する Raect Queryのファイル名を変更した 6c8e0d935146dfd830e0cb1678961454b8a3fc23

## 自動生成したコード

- `api/bundle.yml`
- `backend/src/schema.ts`