### PR TITLE
Set-CookieからCookieが設定されるようにした

### DIFF
--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -113,3 +113,8 @@ migrations_dir = "drizzle/migrations"
 # [[vectorize]]
 # binding = "MY_INDEX"
 # index_name = "my-index"
+
+[dev]
+ip = "localhost"
+port = 8787
+local_protocol = "https"

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -6,3 +6,5 @@ node_modules
 .dev.vars
 
 .wrangler
+
+certs/

--- a/frontend/orval/mutator.ts
+++ b/frontend/orval/mutator.ts
@@ -1,0 +1,14 @@
+export const customFetch = async <T>(
+  url: string,
+  options?: RequestInit
+): Promise<T> => {
+  const res = await fetch(url, {
+    ...options,
+    // 異なるオリジンからのCookieを保存する
+    // 異なるオリジンへCookieを送信する
+    credentials: "include",
+  });
+  const data = await res.json();
+
+  return { status: res.status, data: data };
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,4 +17,11 @@ export default defineConfig({
     }),
     tsconfigPaths(),
   ],
+  server: {
+    proxy: {},
+    https: {
+      key: "./certs/key.pem",
+      cert: "./certs/cert.pem",
+    },
+  },
 });

--- a/orval.config.dev.js
+++ b/orval.config.dev.js
@@ -8,7 +8,13 @@ module.exports = {
       httpClient: 'fetch',
       mode: 'split',
       target: './frontend/orval/client.ts',
-      baseUrl: 'http://localhost:8787' // build時には削除
+      baseUrl: 'http://localhost:8787',
+      override: {
+        mutator: {
+          path: './frontend/orval/mutator.ts',
+          name: 'customFetch',
+        },
+      },
     },
   },
 };

--- a/orval.config.js
+++ b/orval.config.js
@@ -8,6 +8,12 @@ module.exports = {
       httpClient: 'fetch',
       mode: 'split',
       target: './frontend/orval/client.ts',
+      override: {
+        mutator: {
+          path: './frontend/orval/mutator.ts',
+          name: 'customFetch',
+        },
+      },
     },
   },
   zod: {


### PR DESCRIPTION
<!-- Closeするissue番号 -->
- Close #40 

## やったこと

- カスタムのHTTPクライアントを定義した a78318b35c25ac8f4aa44f25a2d9f86c7f9e6007
  - `fetch` に `credentials: 'include'` を渡すため
- バックエンドがHTTPSで起動するようにした f2d3cd75127a7419c4c72806107e272e96eefbfd
- フロントエンドがHTTPSで起動するようにした ad94b6f096f52b9f0f53cb837f663ab2d10139ec

## 確認した方法
- フロントとバック両方のサーバを起動する
- ログインページにアクセスする
- ログインする
- 開発者ツールでCookieが設定されていることを確認する

## スクリーンショット

![image](https://github.com/user-attachments/assets/edbd35df-662f-46d3-99df-73275aad92a1)

## 自動生成したコード
なし
