### PR TITLE
最後のページを超える場合は空の配列を返すようにした

### DIFF
--- a/api/bundle.yml
+++ b/api/bundle.yml
@@ -671,7 +671,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  totalPage:
+                  totalLoan:
                     type: integer
                   loans:
                     type: array

--- a/api/bundle.yml
+++ b/api/bundle.yml
@@ -81,8 +81,8 @@ paths:
               schema:
                 type: object
                 properties:
-                  totalPage:
-                    description: 総ページ数
+                  totalBook:
+                    description: 総書籍数
                     type: integer
                   books:
                     type: array
@@ -820,7 +820,7 @@ paths:
       description: CookieからセッションIDを削除する
       security: []
       responses:
-        '200':
+        '204':
           description: ログアウトに成功した
           headers:
             Set-Cookie:

--- a/api/bundle.yml
+++ b/api/bundle.yml
@@ -426,7 +426,8 @@ paths:
               schema:
                 type: object
                 properties:
-                  totalPage:
+                  totalUser:
+                    description: 総ユーザー数
                     type: integer
                   users:
                     type: array

--- a/api/bundle.yml
+++ b/api/bundle.yml
@@ -304,6 +304,12 @@ paths:
             minimum: 1
             maximum: 40
             default: 10
+        - name: keyword
+          in: query
+          description: 検索キーワード
+          required: false
+          schema:
+            type: string
         - name: intitle
           in: query
           description: タイトル

--- a/api/bundle.yml
+++ b/api/bundle.yml
@@ -337,8 +337,8 @@ paths:
               schema:
                 type: object
                 properties:
-                  totalPage:
-                    description: 総ページ数
+                  totalBook:
+                    description: 総書籍数
                     type: integer
                   books:
                     type: array
@@ -353,6 +353,10 @@ paths:
                             type: string
                         publisher:
                           type: string
+                        publishedDate:
+                          type: string
+                        description:
+                          type: string
                         thumbnail:
                           type: string
                         isbn:
@@ -361,10 +365,10 @@ paths:
                         - title
                         - authors
                 required:
-                  - totalPage
+                  - totalBook
                   - books
               example:
-                totalPage: 3
+                totalBook: 30
                 books:
                   - title: 計算機プログラムの構造と解釈
                     authors:

--- a/api/paths/book.yml
+++ b/api/paths/book.yml
@@ -320,8 +320,8 @@ search:
             schema:
               type: object
               properties:
-                totalPage:
-                  description: 総ページ数
+                totalBook:
+                  description: 総書籍数
                   type: integer
                 books:
                   type: array
@@ -336,6 +336,10 @@ search:
                           type: string
                       publisher:
                         type: string
+                      publishedDate:
+                        type: string
+                      description:
+                        type: string
                       thumbnail:
                         type: string
                       isbn:
@@ -344,10 +348,10 @@ search:
                       - title
                       - authors
               required:
-                - totalPage
+                - totalBook
                 - books
             example:
-              totalPage: 3
+              totalBook: 30
               books:
                 - title: "計算機プログラムの構造と解釈"
                   authors:

--- a/api/paths/book.yml
+++ b/api/paths/book.yml
@@ -58,8 +58,8 @@ books:
             schema:
               type: object
               properties:
-                totalPage:
-                  description: 総ページ数
+                totalBook:
+                  description: 総書籍数
                   type: integer
                 books:
                   type: array

--- a/api/paths/book.yml
+++ b/api/paths/book.yml
@@ -287,6 +287,12 @@ search:
           minimum: 1
           maximum: 40
           default: 10
+      - name: keyword
+        in: query
+        description: 検索キーワード
+        required: false
+        schema:
+          type: string
       - name: intitle
         in: query
         description: タイトル

--- a/api/paths/loan.yml
+++ b/api/paths/loan.yml
@@ -48,7 +48,7 @@ loans:
             schema:
               type: object
               properties:
-                totalPage:
+                totalLoan:
                   type: integer
                 loans:
                   type: array

--- a/api/paths/user.yml
+++ b/api/paths/user.yml
@@ -46,7 +46,8 @@ users:
             schema:
               type: object
               properties:
-                totalPage:
+                totalUser:
+                  description: 総ユーザー数
                   type: integer
                 users:
                   type: array

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,12 +5,12 @@
 pnpm install
 
 # マイグレーションの実行
-pnpm run db:mig:apply:local
+pnpm run db:mig:apply
 
 # サンプルデータの追加
-file=user.sql pnpm run db:seed:local
-file=book.sql pnpm run db:seed:local
-file=loan.sql pnpm run db:seed:local
+file=user.sql pnpm run db:seed
+file=book.sql pnpm run db:seed
+file=loan.sql pnpm run db:seed
 
 # ローカルサーバの起動
 pnpm run dev

--- a/backend/src/api/book.ts
+++ b/backend/src/api/book.ts
@@ -197,7 +197,7 @@ app.get(
 			slicedBooks = hitBooks.slice((page - 1) * limit, page * limit);
 		}
 
-		const responseBody = { totalPage: totalPage, books: slicedBooks };
+		const responseBody = { totalBook: hitBooks.length, books: slicedBooks };
 		const result = getBooksResponse.safeParse(responseBody);
 		if (!result.success) {
 			console.error(result.error);

--- a/backend/src/api/book.ts
+++ b/backend/src/api/book.ts
@@ -191,12 +191,11 @@ app.get(
 
 		// 総ページ数を計算する
 		const totalPage = Math.ceil(hitBooks.length / limit);
-		if (totalPage < page) {
-			return ctx.json({ message: `Page ${page} is out of range` }, 400);
+		let slicedBooks: SelectBook[] = [];
+		if (page <= totalPage) {
+			// 指定されたページの書籍を取得する
+			slicedBooks = hitBooks.slice((page - 1) * limit, page * limit);
 		}
-
-		// 指定されたページの書籍を取得する
-		const slicedBooks = hitBooks.slice((page - 1) * limit, page * limit);
 
 		const responseBody = { totalPage: totalPage, books: slicedBooks };
 		const result = getBooksResponse.safeParse(responseBody);

--- a/backend/src/api/book.ts
+++ b/backend/src/api/book.ts
@@ -189,9 +189,9 @@ app.get(
 			)
 			.orderBy(asc(bookTable.id));
 
+		let slicedBooks: SelectBook[] = [];
 		// 総ページ数を計算する
 		const totalPage = Math.ceil(hitBooks.length / limit);
-		let slicedBooks: SelectBook[] = [];
 		if (page <= totalPage) {
 			// 指定されたページの書籍を取得する
 			slicedBooks = hitBooks.slice((page - 1) * limit, page * limit);

--- a/backend/src/api/book.ts
+++ b/backend/src/api/book.ts
@@ -90,7 +90,7 @@ app.get(
 		delete query['limit'];
 
 		// 絞り込み条件を作成する
-		let terms = '';
+		let terms = query['keyword'] ?? '';
 		for (const [key, value] of Object.entries(query)) {
 			if (value) {
 				terms += `+${key}:${value}`;

--- a/backend/src/api/loan.ts
+++ b/backend/src/api/loan.ts
@@ -1,4 +1,4 @@
-import { bookTable, loanTable, userTable } from '@/drizzle/schema';
+import { bookTable, loanTable, SelectLoan, userTable } from '@/drizzle/schema';
 import { zValidator } from '@hono/zod-validator';
 import camelCase from 'camelcase';
 import { and, asc, eq, Query } from 'drizzle-orm';
@@ -69,14 +69,13 @@ app.get(
 			)
 			.orderBy(asc(loanTable.userId), asc(loanTable.bookId));
 
+		let slicedLoans: SelectLoan[] = [];
 		// 総ページ数を計算する
 		const totalPage = Math.ceil(hitLoans.length / limit);
-		if (totalPage < page) {
-			return ctx.json({ message: `Page ${page} is out of range` }, 400);
+		if (page <= totalPage) {
+			// 指定されたページの貸出履歴を取得する
+			slicedLoans = hitLoans.slice((page - 1) * limit, page * limit);
 		}
-
-		// 指定されたページの貸出履歴を取得する
-		const slicedLoans = hitLoans.slice((page - 1) * limit, page * limit);
 
 		const responseBody = { totalPage: totalPage, loans: slicedLoans };
 		const result = getLoansResponse.safeParse(responseBody);

--- a/backend/src/api/loan.ts
+++ b/backend/src/api/loan.ts
@@ -77,7 +77,7 @@ app.get(
 			slicedLoans = hitLoans.slice((page - 1) * limit, page * limit);
 		}
 
-		const responseBody = { totalPage: totalPage, loans: slicedLoans };
+		const responseBody = { totalLoan: hitLoans.length, loans: slicedLoans };
 		const result = getLoansResponse.safeParse(responseBody);
 		if (!result.success) {
 			console.error(result.error);

--- a/backend/src/api/user.ts
+++ b/backend/src/api/user.ts
@@ -56,14 +56,13 @@ app.get(
 			)
 			.orderBy(asc(userTable.id));
 
+		let slicedUsers: SelectUser[] = [];
 		// 総ページ数を計算する
 		const totalPage = Math.ceil(hitUsers.length / limit);
-		if (totalPage < page) {
-			return ctx.json({ message: `Page ${page} is out of range` }, 400);
+		if (page <= totalPage) {
+			// 指定されたページのユーザを取得する
+			slicedUsers = hitUsers.slice((page - 1) * limit, page * limit);
 		}
-
-		// 指定されたページのユーザを取得する
-		const slicedUsers = hitUsers.slice((page - 1) * limit, page * limit);
 
 		const responseBody = { totalPage: totalPage, users: slicedUsers };
 		const result = getUsersResponse.safeParse(responseBody);

--- a/backend/src/api/user.ts
+++ b/backend/src/api/user.ts
@@ -64,7 +64,7 @@ app.get(
 			slicedUsers = hitUsers.slice((page - 1) * limit, page * limit);
 		}
 
-		const responseBody = { totalPage: totalPage, users: slicedUsers };
+		const responseBody = { totalUser: hitUsers.length, users: slicedUsers };
 		const result = getUsersResponse.safeParse(responseBody);
 		if (!result.success) {
 			console.error(result.error);

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -152,11 +152,13 @@ export const searchBooksQueryParams = zod.object({
 })
 
 export const searchBooksResponse = zod.object({
-  "totalPage": zod.number(),
+  "totalBook": zod.number(),
   "books": zod.array(zod.object({
   "title": zod.string(),
   "authors": zod.array(zod.string()),
   "publisher": zod.string().optional(),
+  "publishedDate": zod.string().optional(),
+  "description": zod.string().optional(),
   "thumbnail": zod.string().optional(),
   "isbn": zod.string().optional()
 }))

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -145,6 +145,7 @@ export const searchBooksQueryIsbnRegExp = new RegExp('^\\d{10}(\\d{3})?$');
 export const searchBooksQueryParams = zod.object({
   "page": zod.string().min(1).regex(searchBooksQueryPageRegExp).optional(),
   "limit": zod.string().min(1).max(searchBooksQueryLimitMax).regex(searchBooksQueryLimitRegExp).optional(),
+  "keyword": zod.string().optional(),
   "intitle": zod.string().optional(),
   "inauthor": zod.string().optional(),
   "inpublisher": zod.string().optional(),

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -31,7 +31,7 @@ export const getBooksResponseBooksItemIsbnRegExp = new RegExp('^\\d{10}(\\d{3})?
 
 
 export const getBooksResponse = zod.object({
-  "totalPage": zod.number(),
+  "totalBook": zod.number().optional(),
   "books": zod.array(zod.object({
   "id": zod.number(),
   "title": zod.string(),
@@ -331,15 +331,6 @@ export const loginResponse = zod.object({
   "name": zod.string(),
   "email": zod.string().email(),
   "sessionToken": zod.string().nullish()
-})
-
-
-/**
- * CookieからセッションIDを削除する
- * @summary ログアウトする
- */
-export const logoutResponse = zod.object({
-  "message": zod.string().optional()
 })
 
 

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -281,7 +281,7 @@ export const getLoansQueryParams = zod.object({
 })
 
 export const getLoansResponse = zod.object({
-  "totalPage": zod.number(),
+  "totalLoan": zod.number().optional(),
   "loans": zod.array(zod.object({
   "userId": zod.number(),
   "bookId": zod.number(),

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -179,7 +179,7 @@ export const getUsersQueryParams = zod.object({
 })
 
 export const getUsersResponse = zod.object({
-  "totalPage": zod.number(),
+  "totalUser": zod.number().optional(),
   "users": zod.array(zod.object({
   "id": zod.number(),
   "name": zod.string(),

--- a/backend/test/api/books.test.ts
+++ b/backend/test/api/books.test.ts
@@ -7,7 +7,7 @@ import { loggedInTest } from '../context/login';
 import { bookFactory } from '../factories/book';
 
 interface GetBooksResponse {
-	totalPage: number;
+	totalBook: number;
 	books: SelectBook[];
 }
 
@@ -34,7 +34,7 @@ describe('GET /books', () => {
 		expect(response.status).toBe(200);
 
 		const body: GetBooksResponse = await response.json();
-		expect(body.totalPage).toBe(2);
+		expect(body.totalBook).toBe(5);
 		expect(body.books).toHaveLength(limit);
 	});
 
@@ -51,13 +51,13 @@ describe('GET /books', () => {
 	it('should return correct book', async () => {
 		const firstBook = { ...books[0], id: 1 };
 
-		const params = new URLSearchParams({ title: firstBook.title }).toString();
+		const params = new URLSearchParams({ isbn: firstBook.isbn }).toString();
 		const response = await app.request(`/books?${params}`, {}, env);
 
 		expect(response.status).toBe(200);
 
 		const body: GetBooksResponse = await response.json();
-		expect(body.totalPage).toBe(1);
+		expect(body.totalBook).toBe(1);
 		expect(body.books).toContainEqual(firstBook);
 	});
 

--- a/backend/test/api/books.test.ts
+++ b/backend/test/api/books.test.ts
@@ -38,6 +38,16 @@ describe('GET /books', () => {
 		expect(body.books).toHaveLength(limit);
 	});
 
+	it('should return empty array when page is out of range', async () => {
+		const params = new URLSearchParams({ page: '3', limit: '3' }).toString();
+		const response = await app.request(`/books?${params}`, {}, env);
+
+		expect(response.status).toBe(200);
+
+		const body: GetBooksResponse = await response.json();
+		expect(body.books).toHaveLength(0);
+	});
+
 	it('should return correct book', async () => {
 		const firstBook = { ...books[0], id: 1 };
 

--- a/backend/test/api/loans.test.ts
+++ b/backend/test/api/loans.test.ts
@@ -82,6 +82,29 @@ describe('GET /loans', () => {
 	);
 
 	loggedInTest(
+		'should return empty array when page is out of range',
+		async ({ currentUser, sessionToken }) => {
+			const response = await app.request(
+				`/loans?page=3&limit=3`,
+				{
+					headers: {
+						Cookie: [
+							`__Secure-user_id=${currentUser.id}`,
+							`__Secure-session_token=${sessionToken}`,
+						].join('; '),
+					},
+				},
+				env,
+			);
+
+			expect(response.status).toBe(200);
+
+			const body: GetLoansResponse = await response.json();
+			expect(body.loans).toHaveLength(0);
+		},
+	);
+
+	loggedInTest(
 		'should return correct loan',
 		async ({ currentUser, sessionToken }) => {
 			const userId = 1;

--- a/backend/test/api/loans.test.ts
+++ b/backend/test/api/loans.test.ts
@@ -14,7 +14,7 @@ import { bookFactory } from '../factories/book';
 import { userFactory } from '../factories/user';
 
 interface GetLoansResponse {
-	totalPage: number;
+	totalLoan: number;
 	loans: SelectLoan[];
 }
 
@@ -74,9 +74,8 @@ describe('GET /loans', () => {
 
 			const body: GetLoansResponse = await response.json();
 			const totalLoan = (users.length - 1) * books.length;
-			const totalPage = Math.ceil(totalLoan / limit);
 
-			expect(body.totalPage).toBe(totalPage);
+			expect(body.totalLoan).toBe(totalLoan);
 			expect(body.loans).toHaveLength(limit);
 		},
 	);
@@ -130,7 +129,7 @@ describe('GET /loans', () => {
 			expect(response.status).toBe(200);
 
 			const body: GetLoansResponse = await response.json();
-			expect(body.totalPage).toBe(1);
+			expect(body.totalLoan).toBe(1);
 
 			const loan = body.loans[0];
 			expect(loan.userId).toBe(userId);

--- a/backend/test/api/users.test.ts
+++ b/backend/test/api/users.test.ts
@@ -38,6 +38,16 @@ describe('GET /users', () => {
 		expect(body.users).toHaveLength(limit);
 	});
 
+	it('should return empty array when page is out of range', async () => {
+		const params = new URLSearchParams({ page: '3', limit: '3' }).toString();
+		const response = await app.request(`/users?${params}`, {}, env);
+
+		expect(response.status).toBe(200);
+
+		const body: GetUsersResponse = await response.json();
+		expect(body.users).toHaveLength(0);
+	});
+
 	it('should return correct user', async () => {
 		const firstUser = {
 			id: 1,

--- a/backend/test/api/users.test.ts
+++ b/backend/test/api/users.test.ts
@@ -7,7 +7,7 @@ import { loggedInTest } from '../context/login';
 import { userFactory } from '../factories/user';
 
 interface GetUsersResponse {
-	totalPage: number;
+	totalUser: number;
 	users: SelectUser[];
 }
 
@@ -34,7 +34,7 @@ describe('GET /users', () => {
 		expect(response.status).toBe(200);
 
 		const body: GetUsersResponse = await response.json();
-		expect(body.totalPage).toBe(2);
+		expect(body.totalUser).toBe(5);
 		expect(body.users).toHaveLength(limit);
 	});
 
@@ -62,7 +62,7 @@ describe('GET /users', () => {
 		expect(response.status).toBe(200);
 
 		const body: GetUsersResponse = await response.json();
-		expect(body.totalPage).toBe(1);
+		expect(body.totalUser).toBe(1);
 		expect(body.users).toContainEqual(firstUser);
 	});
 


### PR DESCRIPTION
<!-- Closeするissue番号 -->
- Close #57 

## やったこと

- 空の配列を返す
  - GET /books 4695e991d0a6607460ba772de0adef44da459cc7
  - GET /users 87deb877fcf9798ec19ae15b94eb66c9e6a6951b
  - GET /loans 32a73eb94fb83b38ded2be7ae1a40c92b4822e8b
- 総ページ数ではなく総件数を返す
  - GET /books d3ca42f6b3606451ea71c46cfff22f49fba7881a
  - GET /users 390ce118569cb6344f14ae719b3bb09df5d5f353
  - GET /loans 56d7c46254c36b3f95c00a21d2c2ac0291717f6b
- GET /books/searchのレスポンスに以下を追加した 2b850d0056e106101ec9fa796065c68a31be2b31
  - 出版日
  - 説明文

## 確認した方法

- ローカルサーバを起動してThunder Clientでリクエストを送る
- テストコードを書く

## 自動生成したコード

なし
