### PR TITLE
「カートに追加」ボタンの色を統一した

### DIFF
--- a/frontend/app/components/books/BookCard.tsx
+++ b/frontend/app/components/books/BookCard.tsx
@@ -1,33 +1,29 @@
-import { Card } from '@mantine/core'
-import BookCardThumbnail from './BookCardThumbnail'
-import type { Book } from 'orval/client.schemas'
-import BookCardHeader from './BookCardHeader'
-import BookCardFooter from './BookCardFooter'
-import { useAtom } from 'jotai'
-import { userAtom, noUser } from '~/stores/userAtom'
+import { Card } from "@mantine/core";
+import { useAtom } from "jotai";
+import type { Book } from "orval/client.schemas";
+import { noUser, userAtom } from "~/stores/userAtom";
+import BookCardFooter from "./BookCardFooter";
+import BookCardHeader from "./BookCardHeader";
+import BookCardThumbnail from "./BookCardThumbnail";
 
 interface BookCardProps {
-  book: Book
+  book: Book;
 }
 
 const BookCard = ({ book }: BookCardProps) => {
-  const [user,] = useAtom(userAtom)
+  const [user] = useAtom(userAtom);
   return (
-    <Card
-      shadow='sm'
-      radius='md'
-      withBorder
-    >
+    <Card shadow="sm" radius="md" pb="xs" withBorder>
       <Card.Section withBorder inheritPadding>
         <BookCardHeader id={book.id} stock={book.stock} />
       </Card.Section>
-      <Card.Section withBorder inheritPadding py='xs'>
+      <Card.Section withBorder inheritPadding py="xs">
         <BookCardThumbnail id={book.id} thumbnail={book.thumbnail} />
       </Card.Section>
 
       {user !== noUser && <BookCardFooter id={book.id} stock={book.stock} />}
-    </Card >
-  )
-}
+    </Card>
+  );
+};
 
-export default BookCard
+export default BookCard;

--- a/frontend/app/components/books/BookCardCartButton.tsx
+++ b/frontend/app/components/books/BookCardCartButton.tsx
@@ -1,26 +1,23 @@
-import { Button } from '@mantine/core'
-import { useAtom } from 'jotai';
+import { Button } from "@mantine/core";
+import { useAtom } from "jotai";
 import { BiSolidCartAdd } from "react-icons/bi";
-import { cartAtom } from '~/stores/cartAtom';
+import { cartAtom } from "~/stores/cartAtom";
 
 interface BookCardCartButtonProps {
-  id: number
-  stock: number
+  id: number;
+  stock: number;
 }
 
-const BookCardCartButton = ({
-  id,
-  stock
-}: BookCardCartButtonProps) => {
-  const [cart, setCart] = useAtom(cartAtom)
+const BookCardCartButton = ({ id, stock }: BookCardCartButtonProps) => {
+  const [cart, setCart] = useAtom(cartAtom);
   const addCart = () => {
-    setCart([...cart, { id, stock }])
-  }
+    setCart([...cart, { id, stock }]);
+  };
   return (
     <Button
-      variant='filled'
-      color='yellow'
-      radius='xl'
+      variant="filled"
+      color="yellow"
+      radius="xl"
       disabled={stock === 0}
       onClick={addCart}
       leftSection={<BiSolidCartAdd />}
@@ -28,7 +25,7 @@ const BookCardCartButton = ({
     >
       カートに入れる
     </Button>
-  )
-}
+  );
+};
 
-export default BookCardCartButton
+export default BookCardCartButton;

--- a/frontend/app/components/books/BookCardCartButton.tsx
+++ b/frontend/app/components/books/BookCardCartButton.tsx
@@ -20,7 +20,7 @@ const BookCardCartButton = ({ id, stock }: BookCardCartButtonProps) => {
       radius="xl"
       disabled={stock === 0}
       onClick={addCart}
-      leftSection={<BiSolidCartAdd />}
+      leftSection={<BiSolidCartAdd size={23} />}
       fz={10}
     >
       カートに入れる

--- a/frontend/app/components/books/BookCards.tsx
+++ b/frontend/app/components/books/BookCards.tsx
@@ -1,33 +1,42 @@
-import { Book } from 'orval/client.schemas'
-import BookCard from './BookCard'
-import { ScrollArea, SimpleGrid } from '@mantine/core'
-import NoBookComponent from './NoBookComponent'
-import { useAtom } from 'jotai'
-import { userAtom, noUser } from '~/stores/userAtom'
-import BookSelectedDialog from './BookSelectedDialog'
+import { ScrollArea, SimpleGrid } from "@mantine/core";
+import { useAtom } from "jotai";
+import { Book } from "orval/client.schemas";
+import { noUser, userAtom } from "~/stores/userAtom";
+import BookCard from "./BookCard";
+import BookSelectedDialog from "./BookSelectedDialog";
+import NoBookComponent from "./NoBookComponent";
 
 interface BookCardsProps {
-  books: Book[]
+  books: Book[];
 }
 
 const BookCards = ({ books }: BookCardsProps) => {
-  const [user, _] = useAtom(userAtom)
-  if (books.length === 0) return <NoBookComponent />
+  const [user, _] = useAtom(userAtom);
+  if (books.length === 0) return <NoBookComponent />;
 
   return (
     <>
-      <ScrollArea h='70dh'>
+      <ScrollArea h="70dh">
         <SimpleGrid
           type="container"
-          cols={{ base: 1, '500px': 3, '700px': 4, '900px': 5, '1200px': 7 }}
-          spacing={{ base: 10, '300px': 'xl' }}
+          cols={{
+            base: 1,
+            "500px": 3,
+            "800px": 4,
+            "1100px": 5,
+            "1400px": 6,
+            "1700px": 7,
+          }}
+          spacing={{ base: 10, "300px": "xl" }}
         >
-          {books.map((book) => <BookCard key={book.id} book={book} />)}
+          {books.map((book) => (
+            <BookCard key={book.id} book={book} />
+          ))}
         </SimpleGrid>
       </ScrollArea>
       {user !== noUser && <BookSelectedDialog />}
     </>
-  )
-}
+  );
+};
 
-export default BookCards
+export default BookCards;

--- a/frontend/app/components/books/BookSelectedDialog.tsx
+++ b/frontend/app/components/books/BookSelectedDialog.tsx
@@ -1,15 +1,14 @@
-import { Button, Center, Dialog, Group, Stack, Text } from '@mantine/core'
-import React from 'react'
-import { selectedBooksAtom } from '~/stores/cartAtom'
-import { useAtom } from 'jotai'
+import { Button, Center, Dialog, Stack, Text } from "@mantine/core";
+import { useAtom } from "jotai";
+import { selectedBooksAtom } from "~/stores/cartAtom";
 
 const BookSelectedDialog = () => {
-  const [selectedBook, setSelectedBook] = useAtom(selectedBooksAtom)
+  const [selectedBook, setSelectedBook] = useAtom(selectedBooksAtom);
   return (
     <Dialog
       opened={selectedBook.length > 0}
       onClose={() => setSelectedBook([])}
-    // size='650px'
+      // size='650px'
     >
       <Stack
         bg="var(--mantine-color-body)"
@@ -18,22 +17,25 @@ const BookSelectedDialog = () => {
         gap="md"
       >
         <Center>
-          <Text fw={500}>
-            選択中の本が{selectedBook.length}冊あります
-          </Text>
+          <Text fw={500}>選択中の本が{selectedBook.length}冊あります</Text>
         </Center>
-        <Button fz='xs'>
+        <Button fz="xs" color="yellow">
           選択中の本をカートに入れる
         </Button>
-        <Button fz='xs' color='red'>
+        <Button fz="xs" color="red">
           選択中の本を削除する
         </Button>
-        <Button fz='xs' variant='light' onClick={() => setSelectedBook([])}>
+        <Button
+          fz="xs"
+          variant="light"
+          style={{ border: "solid" }}
+          onClick={() => setSelectedBook([])}
+        >
           選択を解除する
         </Button>
       </Stack>
     </Dialog>
-  )
-}
+  );
+};
 
-export default BookSelectedDialog
+export default BookSelectedDialog;


### PR DESCRIPTION
<!-- Closeするissue番号 -->
- Close #78 

## やったこと

- ダイアログの「カートに追加」ボタンの色をオレンジにした ceae16167bf634d18ac64c2799baa390571f5dd5
- ダイアログの「選択を解除する」ボタンに枠線を追加した ceae16167bf634d18ac64c2799baa390571f5dd5
- カードの「カートに追加」ボタンのアイコンを大きくした 7680f5ef8e3b6588c6ec0e7ab52cdbc8e91c972a
- カードレイアウトのブレークポイントを変更した 7680f5ef8e3b6588c6ec0e7ab52cdbc8e91c972a

## 確認した方法

```
npm run dev
```

## スクリーンショット

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/7a860763-028a-4747-91db-3c44dff20a85">


## 自動生成したコード

なし
