### PR TITLE
詳細ページの実装

### DIFF
--- a/frontend/app/components/book-detail/BookDetailAuthorBadge.tsx
+++ b/frontend/app/components/book-detail/BookDetailAuthorBadge.tsx
@@ -1,6 +1,4 @@
 import { Badge } from '@mantine/core'
-import { useNavigate } from '@remix-run/react'
-import React from 'react'
 
 interface BookDetailAuthorBadgeProps {
   name: string

--- a/frontend/app/components/book-detail/BookDetailAuthorBadge.tsx
+++ b/frontend/app/components/book-detail/BookDetailAuthorBadge.tsx
@@ -1,0 +1,22 @@
+import { Badge } from '@mantine/core'
+import { useNavigate } from '@remix-run/react'
+import React from 'react'
+
+interface BookDetailAuthorBadgeProps {
+  name: string
+}
+
+const BookDetailAuthorBadge = ({ name }: BookDetailAuthorBadgeProps) => {
+  return (
+    <Badge
+      component='a'
+      href={`/home?author=${name}`}
+      style={{ cursor: 'pointer' }}
+      variant='outline'
+    >
+      {name}
+    </Badge >
+  )
+}
+
+export default BookDetailAuthorBadge

--- a/frontend/app/components/book-detail/BookDetailAuthorBadge.tsx
+++ b/frontend/app/components/book-detail/BookDetailAuthorBadge.tsx
@@ -11,6 +11,7 @@ const BookDetailAuthorBadge = ({ name }: BookDetailAuthorBadgeProps) => {
       href={`/home?author=${name}`}
       style={{ cursor: 'pointer' }}
       variant='outline'
+      size='lg'
     >
       {name}
     </Badge >

--- a/frontend/app/components/book-detail/BookDetailBorrower.tsx
+++ b/frontend/app/components/book-detail/BookDetailBorrower.tsx
@@ -18,11 +18,15 @@ const BookDetailBorrower = () => {
       align='stretch'
       justify='flex-start'
     >
-      <Text>借りている人</Text>
+      <Text fz={rem(18)}>借りている人</Text>
       {loans.isPending ? <Loader color='blue' type='dots' /> :
         <Group gap={rem(7)}>
           {loans.data.data.loans.map((loan) => loan.users &&
-            <Badge key={loan.users.id} variant="light" color="rgba(0, 0, 0, 1)">
+            <Badge key={`${loan.loans?.userId}-${loan.loans?.bookId}`}
+              variant="light"
+              color="rgba(0, 0, 0, 1)"
+              size='lg'
+            >
               {loan.users.name}
             </Badge>
           )}

--- a/frontend/app/components/book-detail/BookDetailBorrower.tsx
+++ b/frontend/app/components/book-detail/BookDetailBorrower.tsx
@@ -1,10 +1,17 @@
-import { Badge, Group, rem, Stack, Text } from '@mantine/core'
+import { Badge, Blockquote, Group, Loader, rem, Stack, Text } from '@mantine/core'
 import { useGetLoans } from 'orval/client'
-import React from 'react'
+import { MdError } from "react-icons/md";
 
 const BookDetailBorrower = () => {
   const loans = useGetLoans()
 
+  if (loans.isError) {
+    return (
+      <Blockquote color="red" icon={<MdError />} mt="xl">
+        データの取得に失敗しました
+      </Blockquote>
+    )
+  }
   return (
     <Stack
       gap='sm'
@@ -12,11 +19,15 @@ const BookDetailBorrower = () => {
       justify='flex-start'
     >
       <Text>借りている人</Text>
-      <Group gap={rem(7)}>
-        <Badge variant="light" color="rgba(0, 0, 0, 1)">
-          {loans.data?.data?.loans.map((loans) => loans.userId)}
-        </Badge>
-      </Group>
+      {loans.isPending ? <Loader color='blue' type='dots' /> :
+        <Group gap={rem(7)}>
+          {loans.data.data.loans.map((loan) => loan.users &&
+            <Badge key={loan.users.id} variant="light" color="rgba(0, 0, 0, 1)">
+              {loan.users.name}
+            </Badge>
+          )}
+        </Group>
+      }
     </Stack>
   )
 }

--- a/frontend/app/components/book-detail/BookDetailBorrower.tsx
+++ b/frontend/app/components/book-detail/BookDetailBorrower.tsx
@@ -1,0 +1,24 @@
+import { Badge, Group, rem, Stack, Text } from '@mantine/core'
+import { useGetLoans } from 'orval/client'
+import React from 'react'
+
+const BookDetailBorrower = () => {
+  const loans = useGetLoans()
+
+  return (
+    <Stack
+      gap='sm'
+      align='stretch'
+      justify='flex-start'
+    >
+      <Text>借りている人</Text>
+      <Group gap={rem(7)}>
+        <Badge variant="light" color="rgba(0, 0, 0, 1)">
+          {loans.data?.data?.loans.map((loans) => loans.userId)}
+        </Badge>
+      </Group>
+    </Stack>
+  )
+}
+
+export default BookDetailBorrower

--- a/frontend/app/components/book-detail/BookDetailComponent.tsx
+++ b/frontend/app/components/book-detail/BookDetailComponent.tsx
@@ -1,10 +1,8 @@
-import React from 'react'
 import { Stack, Grid, rem } from '@mantine/core'
-import { Book } from 'orval/client.schemas'
 import ErrorComponent from '~/components/common/ErrorComponent'
 
 import BookDetailContent from './BookDetailContent'
-import { getBookResponse, getLoansResponse } from 'orval/client'
+import { getBookResponse } from 'orval/client'
 import BookDetailControlPanel from './BookDetailControlPanel'
 
 interface BookDetailComponentProps {
@@ -29,7 +27,7 @@ const BookDetailComponent = ({ bookResponse }: BookDetailComponentProps) => {
     >
       <Grid gutter={rem(50)}>
         <Grid.Col span={4}>
-          <BookDetailControlPanel id={bookResponse.data.id} thumbnail={bookResponse.data.thumbnail} />
+          <BookDetailControlPanel thumbnail={bookResponse.data.thumbnail} />
         </Grid.Col>
         <Grid.Col span={8}>
           <BookDetailContent book={bookResponse.data} />

--- a/frontend/app/components/book-detail/BookDetailComponent.tsx
+++ b/frontend/app/components/book-detail/BookDetailComponent.tsx
@@ -27,7 +27,7 @@ const BookDetailComponent = ({ bookResponse }: BookDetailComponentProps) => {
     >
       <Grid gutter={rem(50)}>
         <Grid.Col span={3}>
-          <BookDetailControlPanel thumbnail={bookResponse.data.thumbnail} />
+          <BookDetailControlPanel id={bookResponse.data.id} thumbnail={bookResponse.data.thumbnail} />
         </Grid.Col>
         <Grid.Col span={9}>
           <BookDetailContent book={bookResponse.data} />

--- a/frontend/app/components/book-detail/BookDetailComponent.tsx
+++ b/frontend/app/components/book-detail/BookDetailComponent.tsx
@@ -26,10 +26,10 @@ const BookDetailComponent = ({ bookResponse }: BookDetailComponentProps) => {
       justify='flex-start'
     >
       <Grid gutter={rem(50)}>
-        <Grid.Col span={4}>
+        <Grid.Col span={3}>
           <BookDetailControlPanel thumbnail={bookResponse.data.thumbnail} />
         </Grid.Col>
-        <Grid.Col span={8}>
+        <Grid.Col span={9}>
           <BookDetailContent book={bookResponse.data} />
         </Grid.Col>
       </Grid>

--- a/frontend/app/components/book-detail/BookDetailComponent.tsx
+++ b/frontend/app/components/book-detail/BookDetailComponent.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { Stack, Grid, rem } from '@mantine/core'
+import { Book } from 'orval/client.schemas'
+import ErrorComponent from '~/components/common/ErrorComponent'
+
+import BookDetailContent from './BookDetailContent'
+import { getBookResponse, getLoansResponse } from 'orval/client'
+import BookDetailControlPanel from './BookDetailControlPanel'
+
+interface BookDetailComponentProps {
+  bookResponse: getBookResponse
+}
+
+const BookDetailComponent = ({ bookResponse }: BookDetailComponentProps) => {
+  switch (bookResponse.status) {
+    case 400:
+      return <ErrorComponent message='リクエストが不正です' />
+    case 404:
+      return <ErrorComponent message='書籍が見つかりません' />
+    case 500:
+      return <ErrorComponent message='サーバーエラーが発生しました' />
+  }
+
+  return (
+    <Stack
+      bg="var(--mantine-color-body)"
+      align="stretch"
+      justify='flex-start'
+    >
+      <Grid gutter={rem(50)}>
+        <Grid.Col span={4}>
+          <BookDetailControlPanel id={bookResponse.data.id} thumbnail={bookResponse.data.thumbnail} />
+        </Grid.Col>
+        <Grid.Col span={8}>
+          <BookDetailContent book={bookResponse.data} />
+        </Grid.Col>
+      </Grid>
+    </Stack>
+  )
+}
+
+export default BookDetailComponent

--- a/frontend/app/components/book-detail/BookDetailComponent.tsx
+++ b/frontend/app/components/book-detail/BookDetailComponent.tsx
@@ -14,7 +14,7 @@ const BookDetailComponent = ({ bookResponse }: BookDetailComponentProps) => {
     case 400:
       return <ErrorComponent message='リクエストが不正です' />
     case 404:
-      return <ErrorComponent message='書籍が見つかりません' />
+      return <ErrorComponent message='書籍が見つかりませんでした' />
     case 500:
       return <ErrorComponent message='サーバーエラーが発生しました' />
   }

--- a/frontend/app/components/book-detail/BookDetailContent.tsx
+++ b/frontend/app/components/book-detail/BookDetailContent.tsx
@@ -4,7 +4,7 @@ import BookDetailTitle from './BookDetailTitle'
 import BookDetailContentTable from './BookDetailContentTable'
 import BookDetailDescription from './BookDetailDescription'
 import { useAtom } from 'jotai'
-import { noUser, userAtom } from '~/stores/userAtom'
+import { userAtom } from '~/stores/userAtom'
 import BookDetailBorrower from './BookDetailBorrower'
 
 interface BookDetailComponentProps {
@@ -23,7 +23,7 @@ const BookDetailContent = ({ book }: BookDetailComponentProps) => {
       <BookDetailTitle title={book.title} />
       <BookDetailContentTable book={book} />
       <BookDetailDescription description={book.description} />
-      {user !== noUser && <BookDetailBorrower />}
+      {!!user && <BookDetailBorrower />}
     </Stack>
   )
 }

--- a/frontend/app/components/book-detail/BookDetailContent.tsx
+++ b/frontend/app/components/book-detail/BookDetailContent.tsx
@@ -1,15 +1,18 @@
 import { Stack } from '@mantine/core'
 import { Book } from 'orval/client.schemas'
-import React from 'react'
 import BookDetailTitle from './BookDetailTitle'
 import BookDetailContentTable from './BookDetailContentTable'
 import BookDetailDescription from './BookDetailDescription'
+import { useAtom } from 'jotai'
+import { noUser, userAtom } from '~/stores/userAtom'
+import BookDetailBorrower from './BookDetailBorrower'
 
 interface BookDetailComponentProps {
   book: Book
 }
 
 const BookDetailContent = ({ book }: BookDetailComponentProps) => {
+  const [user] = useAtom(userAtom)
   return (
     <Stack
       bg="var(--mantine-color-body)"
@@ -20,6 +23,7 @@ const BookDetailContent = ({ book }: BookDetailComponentProps) => {
       <BookDetailTitle title={book.title} />
       <BookDetailContentTable book={book} />
       <BookDetailDescription description={book.description} />
+      {user !== noUser && <BookDetailBorrower />}
     </Stack>
   )
 }

--- a/frontend/app/components/book-detail/BookDetailContent.tsx
+++ b/frontend/app/components/book-detail/BookDetailContent.tsx
@@ -1,0 +1,27 @@
+import { Stack } from '@mantine/core'
+import { Book } from 'orval/client.schemas'
+import React from 'react'
+import BookDetailTitle from './BookDetailTitle'
+import BookDetailContentTable from './BookDetailContentTable'
+import BookDetailDescription from './BookDetailDescription'
+
+interface BookDetailComponentProps {
+  book: Book
+}
+
+const BookDetailContent = ({ book }: BookDetailComponentProps) => {
+  return (
+    <Stack
+      bg="var(--mantine-color-body)"
+      align="stretch"
+      justify='flex-start'
+      gap='xl'
+    >
+      <BookDetailTitle title={book.title} />
+      <BookDetailContentTable book={book} />
+      <BookDetailDescription description={book.description} />
+    </Stack>
+  )
+}
+
+export default BookDetailContent

--- a/frontend/app/components/book-detail/BookDetailContentTable.tsx
+++ b/frontend/app/components/book-detail/BookDetailContentTable.tsx
@@ -1,0 +1,44 @@
+import { Group, rem, Stack, Table, Text } from '@mantine/core'
+import { Book } from 'orval/client.schemas'
+import React from 'react'
+import BookDetailAuthorBadge from './BookDetailAuthorBadge'
+
+interface BookDetailContentTableProps {
+  book: Book
+}
+
+const BookDetailContentTable = ({ book }: BookDetailContentTableProps) => {
+  return (
+    <Stack
+      gap='sm'
+      align='stretch'
+      justify='flex-start'
+    >
+      <Text>書籍情報</Text>
+      <Table>
+        <Table.Tr>
+          <Table.Th>著者</Table.Th>
+          <Table.Td><Group gap={rem(7)}>{book.authors.map((author) => <BookDetailAuthorBadge name={author} />)}</Group></Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Th>出版社</Table.Th>
+          <Table.Td>{book.publisher}</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Th>出版日</Table.Th>
+          <Table.Td>{book.publishedDate}</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Th>ISBN</Table.Th>
+          <Table.Td>{book.isbn}</Table.Td>
+        </Table.Tr>
+        <Table.Tr>
+          <Table.Th>在庫数</Table.Th>
+          <Table.Td>{book.stock}</Table.Td>
+        </Table.Tr>
+      </Table>
+    </Stack>
+  )
+}
+
+export default BookDetailContentTable

--- a/frontend/app/components/book-detail/BookDetailContentTable.tsx
+++ b/frontend/app/components/book-detail/BookDetailContentTable.tsx
@@ -13,10 +13,10 @@ const BookDetailContentTable = ({ book }: BookDetailContentTableProps) => {
       align='stretch'
       justify='flex-start'
     >
-      <Text>書籍情報</Text>
-      <Table>
+      <Text fz={rem(22)}>書籍情報</Text>
+      <Table fz={rem(17)}>
         <Table.Tr key={"author"}>
-          <Table.Th>著者</Table.Th>
+          <Table.Th >著者</Table.Th>
           <Table.Td><Group gap={rem(7)}>{book.authors.map((author, id) => <BookDetailAuthorBadge key={id} name={author} />)}</Group></Table.Td>
         </Table.Tr>
         <Table.Tr key={"publisher"}>

--- a/frontend/app/components/book-detail/BookDetailContentTable.tsx
+++ b/frontend/app/components/book-detail/BookDetailContentTable.tsx
@@ -23,7 +23,7 @@ const BookDetailContentTable = ({ book }: BookDetailContentTableProps) => {
           <Table.Th>出版社</Table.Th>
           <Table.Td>{book.publisher}</Table.Td>
         </Table.Tr>
-        <Table.Tr key={"publishDate"}>
+        <Table.Tr key={"publishedDate"}>
           <Table.Th>出版日</Table.Th>
           <Table.Td>{book.publishedDate}</Table.Td>
         </Table.Tr>

--- a/frontend/app/components/book-detail/BookDetailContentTable.tsx
+++ b/frontend/app/components/book-detail/BookDetailContentTable.tsx
@@ -1,6 +1,5 @@
 import { Group, rem, Stack, Table, Text } from '@mantine/core'
 import { Book } from 'orval/client.schemas'
-import React from 'react'
 import BookDetailAuthorBadge from './BookDetailAuthorBadge'
 
 interface BookDetailContentTableProps {
@@ -16,23 +15,23 @@ const BookDetailContentTable = ({ book }: BookDetailContentTableProps) => {
     >
       <Text>書籍情報</Text>
       <Table>
-        <Table.Tr>
+        <Table.Tr key={"author"}>
           <Table.Th>著者</Table.Th>
-          <Table.Td><Group gap={rem(7)}>{book.authors.map((author) => <BookDetailAuthorBadge name={author} />)}</Group></Table.Td>
+          <Table.Td><Group gap={rem(7)}>{book.authors.map((author, id) => <BookDetailAuthorBadge key={id} name={author} />)}</Group></Table.Td>
         </Table.Tr>
-        <Table.Tr>
+        <Table.Tr key={"publisher"}>
           <Table.Th>出版社</Table.Th>
           <Table.Td>{book.publisher}</Table.Td>
         </Table.Tr>
-        <Table.Tr>
+        <Table.Tr key={"publishDate"}>
           <Table.Th>出版日</Table.Th>
           <Table.Td>{book.publishedDate}</Table.Td>
         </Table.Tr>
-        <Table.Tr>
+        <Table.Tr key={"isbn"}>
           <Table.Th>ISBN</Table.Th>
           <Table.Td>{book.isbn}</Table.Td>
         </Table.Tr>
-        <Table.Tr>
+        <Table.Tr key={"stock"}>
           <Table.Th>在庫数</Table.Th>
           <Table.Td>{book.stock}</Table.Td>
         </Table.Tr>

--- a/frontend/app/components/book-detail/BookDetailControlPanel.tsx
+++ b/frontend/app/components/book-detail/BookDetailControlPanel.tsx
@@ -2,7 +2,7 @@ import { Button, Stack } from '@mantine/core'
 import BookDetailThumbnail from './BookDetailThumbnail'
 import { MdEdit, MdDeleteForever } from "react-icons/md";
 import { useAtom } from 'jotai';
-import { noUser, userAtom } from '~/stores/userAtom';
+import { userAtom } from '~/stores/userAtom';
 import { Form, useFetcher, useNavigate } from '@remix-run/react';
 
 interface BookDetailControlPanelProps {
@@ -22,7 +22,7 @@ const BookDetailControlPanel = ({ id, thumbnail }: BookDetailControlPanelProps) 
       gap='md'
     >
       <BookDetailThumbnail thumbnail={thumbnail} />
-      {user !== noUser &&
+      {!!user &&
         <Button
           leftSection={<MdEdit />}
           fz='lg'
@@ -30,7 +30,7 @@ const BookDetailControlPanel = ({ id, thumbnail }: BookDetailControlPanelProps) 
         >
           編集
         </Button>}
-      {user !== noUser &&
+      {!!user &&
         <Button
           color='red'
           leftSection={<MdDeleteForever />}

--- a/frontend/app/components/book-detail/BookDetailControlPanel.tsx
+++ b/frontend/app/components/book-detail/BookDetailControlPanel.tsx
@@ -35,6 +35,7 @@ const BookDetailControlPanel = ({ id, thumbnail }: BookDetailControlPanelProps) 
           color='red'
           leftSection={<MdDeleteForever />}
           fz='lg'
+          // action : home.books.$bookId.tsx
           onClick={() => fetcher.submit({ bookId: id }, { method: 'delete' })}
           disabled={fetcher.state === 'submitting'}
         >

--- a/frontend/app/components/book-detail/BookDetailControlPanel.tsx
+++ b/frontend/app/components/book-detail/BookDetailControlPanel.tsx
@@ -1,0 +1,29 @@
+import { Button, Stack } from '@mantine/core'
+import BookDetailThumbnail from './BookDetailThumbnail'
+import { MdEdit } from "react-icons/md";
+import { MdDeleteForever } from "react-icons/md";
+import { useAtom } from 'jotai';
+import { noUser, userAtom } from '~/stores/userAtom';
+
+interface BookDetailControlPanelProps {
+  id: number
+  thumbnail?: string
+}
+
+const BookDetailControlPanel = ({ id, thumbnail }: BookDetailControlPanelProps) => {
+  const [user,] = useAtom(userAtom)
+  return (
+    <Stack
+      bg="var(--mantine-color-body)"
+      align="stretch"
+      justify='center'
+      gap='md'
+    >
+      <BookDetailThumbnail thumbnail={thumbnail} />
+      {user !== noUser && <Button leftSection={<MdEdit />} fz='lg' >編集</Button>}
+      {user !== noUser && <Button color='red' leftSection={<MdDeleteForever />} fz='lg'>削除</Button>}
+    </Stack>
+  )
+}
+
+export default BookDetailControlPanel

--- a/frontend/app/components/book-detail/BookDetailControlPanel.tsx
+++ b/frontend/app/components/book-detail/BookDetailControlPanel.tsx
@@ -3,13 +3,17 @@ import BookDetailThumbnail from './BookDetailThumbnail'
 import { MdEdit, MdDeleteForever } from "react-icons/md";
 import { useAtom } from 'jotai';
 import { noUser, userAtom } from '~/stores/userAtom';
+import { Form, useFetcher, useNavigate } from '@remix-run/react';
 
 interface BookDetailControlPanelProps {
+  id: number
   thumbnail?: string
 }
 
-const BookDetailControlPanel = ({ thumbnail }: BookDetailControlPanelProps) => {
+const BookDetailControlPanel = ({ id, thumbnail }: BookDetailControlPanelProps) => {
   const [user,] = useAtom(userAtom)
+  const fetcher = useFetcher()
+  const navigate = useNavigate()
   return (
     <Stack
       bg="var(--mantine-color-body)"
@@ -18,8 +22,24 @@ const BookDetailControlPanel = ({ thumbnail }: BookDetailControlPanelProps) => {
       gap='md'
     >
       <BookDetailThumbnail thumbnail={thumbnail} />
-      {user !== noUser && <Button leftSection={<MdEdit />} fz='lg' >編集</Button>}
-      {user !== noUser && <Button color='red' leftSection={<MdDeleteForever />} fz='lg'>削除</Button>}
+      {user !== noUser &&
+        <Button
+          leftSection={<MdEdit />}
+          fz='lg'
+          onClick={() => navigate("edit")}
+        >
+          編集
+        </Button>}
+      {user !== noUser &&
+        <Button
+          color='red'
+          leftSection={<MdDeleteForever />}
+          fz='lg'
+          onClick={() => fetcher.submit({ bookId: id }, { method: 'delete' })}
+          disabled={fetcher.state === 'submitting'}
+        >
+          削除
+        </Button>}
     </Stack>
   )
 }

--- a/frontend/app/components/book-detail/BookDetailControlPanel.tsx
+++ b/frontend/app/components/book-detail/BookDetailControlPanel.tsx
@@ -1,16 +1,14 @@
 import { Button, Stack } from '@mantine/core'
 import BookDetailThumbnail from './BookDetailThumbnail'
-import { MdEdit } from "react-icons/md";
-import { MdDeleteForever } from "react-icons/md";
+import { MdEdit, MdDeleteForever } from "react-icons/md";
 import { useAtom } from 'jotai';
 import { noUser, userAtom } from '~/stores/userAtom';
 
 interface BookDetailControlPanelProps {
-  id: number
   thumbnail?: string
 }
 
-const BookDetailControlPanel = ({ id, thumbnail }: BookDetailControlPanelProps) => {
+const BookDetailControlPanel = ({ thumbnail }: BookDetailControlPanelProps) => {
   const [user,] = useAtom(userAtom)
   return (
     <Stack

--- a/frontend/app/components/book-detail/BookDetailDescription.tsx
+++ b/frontend/app/components/book-detail/BookDetailDescription.tsx
@@ -1,0 +1,16 @@
+import { Text } from '@mantine/core'
+import React from 'react'
+
+interface BookDetailDescriptionProps {
+  description: string
+}
+
+const BookDetailDescription = ({ description }: BookDetailDescriptionProps) => {
+  return (
+    <Text>
+      {description}
+    </Text>
+  )
+}
+
+export default BookDetailDescription

--- a/frontend/app/components/book-detail/BookDetailDescription.tsx
+++ b/frontend/app/components/book-detail/BookDetailDescription.tsx
@@ -6,7 +6,7 @@ interface BookDetailDescriptionProps {
 
 const BookDetailDescription = ({ description }: BookDetailDescriptionProps) => {
   return (
-    <Text>
+    <Text fz={18}>
       {description}
     </Text>
   )

--- a/frontend/app/components/book-detail/BookDetailDescription.tsx
+++ b/frontend/app/components/book-detail/BookDetailDescription.tsx
@@ -1,5 +1,4 @@
 import { Text } from '@mantine/core'
-import React from 'react'
 
 interface BookDetailDescriptionProps {
   description: string

--- a/frontend/app/components/book-detail/BookDetailThumbnail.tsx
+++ b/frontend/app/components/book-detail/BookDetailThumbnail.tsx
@@ -1,5 +1,4 @@
-import { AspectRatio, Card, Image, rem } from '@mantine/core'
-import { useNavigate } from '@remix-run/react'
+import { AspectRatio, Image, rem } from '@mantine/core'
 import NoImage from '~/img/noImage.png'
 
 interface BookDetailThumbnailProps {

--- a/frontend/app/components/book-detail/BookDetailThumbnail.tsx
+++ b/frontend/app/components/book-detail/BookDetailThumbnail.tsx
@@ -1,0 +1,23 @@
+import { AspectRatio, Card, Image, rem } from '@mantine/core'
+import { useNavigate } from '@remix-run/react'
+import NoImage from '~/img/noImage.png'
+
+interface BookDetailThumbnailProps {
+  thumbnail?: string
+}
+
+const BookDetailThumbnail = ({ thumbnail }: BookDetailThumbnailProps) => {
+  return (
+    <AspectRatio ratio={10 / 14}
+      style={{ flex: `0 0 ${rem(400)}`, cursor: 'pointer' }}
+      component='div'
+    >
+      <Image
+        src={thumbnail ? thumbnail : NoImage}
+        alt='Book cover'
+      />
+    </AspectRatio>
+  )
+}
+
+export default BookDetailThumbnail

--- a/frontend/app/components/book-detail/BookDetailTitle.tsx
+++ b/frontend/app/components/book-detail/BookDetailTitle.tsx
@@ -1,5 +1,4 @@
 import { Title } from '@mantine/core'
-import React from 'react'
 
 interface BookDetailTitleProps {
   title: string

--- a/frontend/app/components/book-detail/BookDetailTitle.tsx
+++ b/frontend/app/components/book-detail/BookDetailTitle.tsx
@@ -1,0 +1,14 @@
+import { Title } from '@mantine/core'
+import React from 'react'
+
+interface BookDetailTitleProps {
+  title: string
+}
+
+const BookDetailTitle = ({ title }: BookDetailTitleProps) => {
+  return (
+    <Title order={1}>{title}</Title>
+  )
+}
+
+export default BookDetailTitle

--- a/frontend/app/components/book-search/BookSearchComponent.tsx
+++ b/frontend/app/components/book-search/BookSearchComponent.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import BookSearchModeButton from './BookSearchModeButton'
 import type { UseFormReturnType } from '@mantine/form'
 import type { GetBooksParams } from 'orval/client.schemas'

--- a/frontend/app/components/book-search/BookSearchModeButton.tsx
+++ b/frontend/app/components/book-search/BookSearchModeButton.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@mantine/core'
-import React from 'react'
 
 interface SearchModeButtonProps {
   isOpen: boolean

--- a/frontend/app/components/books/BookCard.tsx
+++ b/frontend/app/components/books/BookCard.tsx
@@ -1,7 +1,7 @@
 import { Card } from "@mantine/core";
 import { useAtom } from "jotai";
 import type { Book } from "orval/client.schemas";
-import { noUser, userAtom } from "~/stores/userAtom";
+import { userAtom } from "~/stores/userAtom";
 import BookCardFooter from "./BookCardFooter";
 import BookCardHeader from "./BookCardHeader";
 import BookCardThumbnail from "./BookCardThumbnail";
@@ -21,7 +21,7 @@ const BookCard = ({ book }: BookCardProps) => {
         <BookCardThumbnail id={book.id} thumbnail={book.thumbnail} />
       </Card.Section>
 
-      {user !== noUser && <BookCardFooter id={book.id} stock={book.stock} />}
+      {!!user && <BookCardFooter id={book.id} stock={book.stock} />}
     </Card>
   );
 };

--- a/frontend/app/components/books/BookCardFooter.tsx
+++ b/frontend/app/components/books/BookCardFooter.tsx
@@ -1,5 +1,4 @@
 import { Center } from '@mantine/core'
-import React from 'react'
 import BookCardCartButton from './BookCardCartButton'
 
 interface BookCardFooterProps {

--- a/frontend/app/components/books/BookCardHeader.tsx
+++ b/frontend/app/components/books/BookCardHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Checkbox, Group } from '@mantine/core'
 import { selectedBooksAtom } from '~/stores/cartAtom'
 import { useAtom } from 'jotai'

--- a/frontend/app/components/books/BookCardHeader.tsx
+++ b/frontend/app/components/books/BookCardHeader.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, Group } from '@mantine/core'
 import { selectedBooksAtom } from '~/stores/cartAtom'
 import { useAtom } from 'jotai'
-import { userAtom, noUser } from '~/stores/userAtom'
+import { userAtom } from '~/stores/userAtom'
 import type { CartProps } from '~/stores/cartAtom'
 import BookCardHeaderBadge from './BookCardHeaderBadge'
 
@@ -27,8 +27,8 @@ const BookCardHeader = ({ id, stock }: BookCardHeaderProps) => {
   }
 
   return (
-    <Group justify={user !== noUser ? 'space-between' : 'flex-end'} py={10}>
-      {user !== noUser && <Checkbox value={id} checked={selectedBook.some(selectedCheck)} onChange={selectedBookAdd} />}
+    <Group justify={!!user ? 'space-between' : 'flex-end'} py={10}>
+      {!!user && <Checkbox value={id} checked={selectedBook.some(selectedCheck)} onChange={selectedBookAdd} />}
       <BookCardHeaderBadge stock={stock} />
     </Group>
   )

--- a/frontend/app/components/books/BookCardHeaderBadge.tsx
+++ b/frontend/app/components/books/BookCardHeaderBadge.tsx
@@ -1,5 +1,4 @@
 import { Badge } from '@mantine/core'
-import React from 'react'
 
 interface BookCardHeaderBadgeProps {
   stock: number

--- a/frontend/app/components/books/BookCardThumbnail.tsx
+++ b/frontend/app/components/books/BookCardThumbnail.tsx
@@ -1,4 +1,4 @@
-import { AspectRatio, Card, Image, rem } from '@mantine/core'
+import { AspectRatio, Image, rem } from '@mantine/core'
 import { useNavigate } from '@remix-run/react'
 import NoImage from '~/img/noImage.png'
 

--- a/frontend/app/components/books/BookCards.tsx
+++ b/frontend/app/components/books/BookCards.tsx
@@ -11,7 +11,7 @@ interface BookCardsProps {
 }
 
 const BookCards = ({ books }: BookCardsProps) => {
-  const [user, _] = useAtom(userAtom);
+  const [user] = useAtom(userAtom);
   if (books.length === 0) return <NoBookComponent />;
 
   return (

--- a/frontend/app/components/books/BookCards.tsx
+++ b/frontend/app/components/books/BookCards.tsx
@@ -1,7 +1,7 @@
 import { ScrollArea, SimpleGrid } from "@mantine/core";
 import { useAtom } from "jotai";
 import { Book } from "orval/client.schemas";
-import { noUser, userAtom } from "~/stores/userAtom";
+import { userAtom } from "~/stores/userAtom";
 import BookCard from "./BookCard";
 import BookSelectedDialog from "./BookSelectedDialog";
 import NoBookComponent from "./NoBookComponent";
@@ -34,7 +34,7 @@ const BookCards = ({ books }: BookCardsProps) => {
           ))}
         </SimpleGrid>
       </ScrollArea>
-      {user !== noUser && <BookSelectedDialog />}
+      {!!user && <BookSelectedDialog />}
     </>
   );
 };

--- a/frontend/app/components/books/BookListComponent.tsx
+++ b/frontend/app/components/books/BookListComponent.tsx
@@ -1,4 +1,4 @@
-import { AppShell, Space, Stack } from '@mantine/core'
+import { Stack } from '@mantine/core'
 import { getBooksResponse } from 'orval/client'
 import ErrorComponent from '../common/ErrorComponent'
 import BookCards from './BookCards'

--- a/frontend/app/components/books/BookListComponent.tsx
+++ b/frontend/app/components/books/BookListComponent.tsx
@@ -1,6 +1,6 @@
 import { AppShell, Space, Stack } from '@mantine/core'
 import { getBooksResponse } from 'orval/client'
-import ErrorBookComponent from './ErrorBookComponent'
+import ErrorComponent from '../common/ErrorComponent'
 import BookCards from './BookCards'
 import type { UseFormReturnType } from '@mantine/form'
 import type { GetBooksParams } from 'orval/client.schemas'
@@ -36,18 +36,16 @@ const BookListComponent = ({
   totalBook
 }: BookListComponentProps) => {
   return (
-    <AppShell.Main>
-      <Stack
-        bg="var(--mantine-color-body)"
-        align="stretch"
-        justify='flex-start'
-      >
-        <BookSearchComponent isOpen={isOpen} open={open} close={close} form={form} handleSubmit={handleSubmit} />
-        <ContentsHeader page={page} limit={limit} total={totalBook} handleLimitChange={handleLimitChange} />
-        {booksResponse.status !== 200 ? <ErrorBookComponent /> : <BookCards books={booksResponse.data.books} />}
-        <PaginationComponent totalNum={totalBook} page={page} limit={limit} handlePaginationChange={handlePaginationChange} />
-      </Stack>
-    </AppShell.Main>
+    <Stack
+      bg="var(--mantine-color-body)"
+      align="stretch"
+      justify='flex-start'
+    >
+      <BookSearchComponent isOpen={isOpen} open={open} close={close} form={form} handleSubmit={handleSubmit} />
+      <ContentsHeader page={page} limit={limit} total={totalBook} handleLimitChange={handleLimitChange} />
+      {booksResponse.status !== 200 ? <ErrorComponent message={"書籍情報を取得できませんでした。"} /> : <BookCards books={booksResponse.data.books} />}
+      <PaginationComponent totalNum={totalBook} page={page} limit={limit} handlePaginationChange={handlePaginationChange} />
+    </Stack>
   )
 }
 

--- a/frontend/app/components/books/BookSelectedDialog.tsx
+++ b/frontend/app/components/books/BookSelectedDialog.tsx
@@ -8,7 +8,6 @@ const BookSelectedDialog = () => {
     <Dialog
       opened={selectedBook.length > 0}
       onClose={() => setSelectedBook([])}
-      // size='650px'
     >
       <Stack
         bg="var(--mantine-color-body)"

--- a/frontend/app/components/common/ContentsHeader.tsx
+++ b/frontend/app/components/common/ContentsHeader.tsx
@@ -1,5 +1,4 @@
 import { Group } from '@mantine/core'
-import React from 'react'
 import LimitSelect from './LimitSelect'
 import CurrentContentNumber from './CurrentContentNumber'
 

--- a/frontend/app/components/common/CurrentContentNumber.tsx
+++ b/frontend/app/components/common/CurrentContentNumber.tsx
@@ -1,5 +1,4 @@
 import { Text } from '@mantine/core'
-import React from 'react'
 
 interface CurrentContentNumberProps {
   start: number,

--- a/frontend/app/components/common/ErrorComponent.tsx
+++ b/frontend/app/components/common/ErrorComponent.tsx
@@ -1,14 +1,19 @@
 import { Blockquote, Center } from '@mantine/core'
 import { MdError } from "react-icons/md";
 
-const ErrorBookComponent = () => {
+interface ErrorComponentProps {
+  message: string
+}
+
+
+const ErrorComponent = ({ message }: ErrorComponentProps) => {
   return (
     <Center h='70dh' w='100%'>
       <Blockquote color="red" icon={<MdError />} mt="xl">
-        書籍情報を取得できませんでした。
+        {message}
       </Blockquote>
     </Center>
   )
 }
 
-export default ErrorBookComponent
+export default ErrorComponent

--- a/frontend/app/components/common/LimitSelect.tsx
+++ b/frontend/app/components/common/LimitSelect.tsx
@@ -1,5 +1,4 @@
 import { NativeSelect } from '@mantine/core'
-import React from 'react'
 
 interface LimitSelectProps {
   value?: number

--- a/frontend/app/components/common/PaginationComponent.tsx
+++ b/frontend/app/components/common/PaginationComponent.tsx
@@ -1,5 +1,4 @@
 import { Center, Pagination } from '@mantine/core'
-import React from 'react'
 
 interface PaginationComponentProps {
   totalNum: number

--- a/frontend/app/components/header/HeaderBookMenu.tsx
+++ b/frontend/app/components/header/HeaderBookMenu.tsx
@@ -9,8 +9,6 @@ import { useAtom } from "jotai";
 const HeaderBookMenu = () => {
   const navigate = useNavigate()
   const [user,] = useAtom(userAtom)
-  // 書籍一覧ページ(`/home`)に遷移すると、ヘッダーの部分がMainコンポーネントとして表示されてしまい、ページの頭に空白ができる。
-  // そのため、`/home#search-mode-button`に遷移することで、ヘッダーの部分が表示されないようにする。
   return (
     <Menu shadow="md">
       <Menu.Target>
@@ -19,7 +17,7 @@ const HeaderBookMenu = () => {
         </Button>
       </Menu.Target>
       <Menu.Dropdown>
-        <Menu.Item leftSection={<LuBookCopy />} onClick={() => navigate('/home#search-mode-button')}>
+        <Menu.Item leftSection={<LuBookCopy />} onClick={() => navigate('/home')}>
           書籍一覧
         </Menu.Item>
         {(user !== noUser) && <Menu.Item leftSection={<BiSolidBookAdd />} onClick={() => navigate('/home/books/new')}>

--- a/frontend/app/components/header/HeaderBookMenu.tsx
+++ b/frontend/app/components/header/HeaderBookMenu.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "@remix-run/react";
 import { FaBook } from "react-icons/fa";
 import { LuBookCopy } from "react-icons/lu";
 import { BiSolidBookAdd } from "react-icons/bi";
-import { userAtom, noUser } from "~/stores/userAtom";
+import { userAtom } from "~/stores/userAtom";
 import { useAtom } from "jotai";
 
 const HeaderBookMenu = () => {
@@ -20,7 +20,7 @@ const HeaderBookMenu = () => {
         <Menu.Item leftSection={<LuBookCopy />} onClick={() => navigate('/home')}>
           書籍一覧
         </Menu.Item>
-        {(user !== noUser) && <Menu.Item leftSection={<BiSolidBookAdd />} onClick={() => navigate('/home/books/new')}>
+        {!!user && <Menu.Item leftSection={<BiSolidBookAdd />} onClick={() => navigate('/home/books/new')}>
           書籍追加
         </Menu.Item>}
 

--- a/frontend/app/components/header/HeaderComponent.tsx
+++ b/frontend/app/components/header/HeaderComponent.tsx
@@ -4,7 +4,7 @@ import HeaderMainComponent from './HeaderMainComponent'
 import { useAtom } from "jotai"
 import { getUser } from "orval/client"
 import { User } from "orval/client.schemas"
-import { userAtom, noUser } from "~/stores/userAtom"
+import { userAtom } from "~/stores/userAtom"
 
 const getCookieUserId = () => {
   if (typeof document === "undefined") return undefined
@@ -18,7 +18,7 @@ const HeaderComponent = () => {
   const [user, setUser] = useAtom(userAtom)
   const userId = getCookieUserId()
   if (userId) {
-    if (user === noUser) {
+    if (!user) {
       // ユーザ情報を取得するAPIを呼び出す。
       getUser(userId).then((response) => {
         if (response.status === 200) {

--- a/frontend/app/components/header/HeaderComponent.tsx
+++ b/frontend/app/components/header/HeaderComponent.tsx
@@ -17,7 +17,7 @@ const getCookieUserId = () => {
 const HeaderComponent = () => {
   const [user, setUser] = useAtom(userAtom)
   const userId = getCookieUserId()
-  if (!!userId) {
+  if (userId) {
     if (user === noUser) {
       // ユーザ情報を取得するAPIを呼び出す。
       getUser(userId).then((response) => {

--- a/frontend/app/components/header/HeaderLoginComponent.tsx
+++ b/frontend/app/components/header/HeaderLoginComponent.tsx
@@ -22,9 +22,7 @@ const HeaderLoginComponent = () => {
           case 204:
             setUser(noUser)
             successNotifications('ログアウトしました')
-            // 書籍一覧ページ(`/home`)に遷移すると、ヘッダーの部分がMainコンポーネントとして表示されてしまい、ページの頭に空白ができる。
-            // そのため、`/home#search-mode-button`に遷移することで、ヘッダーの部分が表示されないようにする。
-            navigate('/home#search-mode-button')
+            navigate('/home')
             break
           case 500:
             errorNotifications('サーバーエラーが発生しました')

--- a/frontend/app/components/header/HeaderLoginComponent.tsx
+++ b/frontend/app/components/header/HeaderLoginComponent.tsx
@@ -11,7 +11,7 @@ import { useAtom } from 'jotai';
 import { userAtom, noUser } from '~/stores/userAtom';
 
 const HeaderLoginComponent = () => {
-  const [user, setUser] = useAtom(userAtom)
+  const [, setUser] = useAtom(userAtom)
   const [opened, { open, close }] = useDisclosure()
   const navigate = useNavigate()
   const logoutTask = useLogout()

--- a/frontend/app/components/header/HeaderLoginComponent.tsx
+++ b/frontend/app/components/header/HeaderLoginComponent.tsx
@@ -8,7 +8,7 @@ import { LuLogOut } from "react-icons/lu";
 import { errorNotifications, successNotifications } from '~/utils/notification';
 import HeaderUsersMenu from './HeaderUsersMenu';
 import { useAtom } from 'jotai';
-import { userAtom, noUser } from '~/stores/userAtom';
+import { userAtom } from '~/stores/userAtom';
 
 const HeaderLoginComponent = () => {
   const [, setUser] = useAtom(userAtom)
@@ -20,7 +20,7 @@ const HeaderLoginComponent = () => {
       onSuccess: (response) => {
         switch (response.status) {
           case 204:
-            setUser(noUser)
+            setUser(undefined)
             successNotifications('ログアウトしました')
             navigate('/home')
             break

--- a/frontend/app/components/header/HeaderMainComponent.tsx
+++ b/frontend/app/components/header/HeaderMainComponent.tsx
@@ -1,12 +1,12 @@
 import HeaderLoginComponent from './HeaderLoginComponent'
 import HeaderLogoutComponent from './HeaderLogoutComponent'
 import { useAtom } from "jotai"
-import { userAtom, noUser } from "~/stores/userAtom"
+import { userAtom } from "~/stores/userAtom"
 
 const HeaderMainComponent = () => {
   const [user,] = useAtom(userAtom)
 
-  return <>{(user === noUser) ? <HeaderLogoutComponent /> : <HeaderLoginComponent/>}</>
+  return <>{!user ? <HeaderLogoutComponent /> : <HeaderLoginComponent />}</>
 }
 
 export default HeaderMainComponent

--- a/frontend/app/components/header/HeaderUserMenu.tsx
+++ b/frontend/app/components/header/HeaderUserMenu.tsx
@@ -1,8 +1,6 @@
 import { Button, Menu } from '@mantine/core'
-import { FaUserCircle } from "react-icons/fa";
-import { FaUser } from "react-icons/fa";
-import { LuShoppingCart } from "react-icons/lu";
-import { LuLogOut } from "react-icons/lu";
+import { FaUserCircle, FaUser } from "react-icons/fa";
+import { LuLogOut, LuShoppingCart } from "react-icons/lu";
 import { userAtom } from '~/stores/userAtom';
 import { useAtom } from 'jotai';
 import { useNavigate } from '@remix-run/react';

--- a/frontend/app/components/header/HeaderUserMenu.tsx
+++ b/frontend/app/components/header/HeaderUserMenu.tsx
@@ -16,7 +16,7 @@ const HeaderUserMenu = ({ open }: HeaderUserMenuProps) => {
     <Menu shadow="md">
       <Menu.Target>
         <Button leftSection={<FaUserCircle />} variant="default" >
-          {user.name}
+          {user?.name}
         </Button>
       </Menu.Target>
       <Menu.Dropdown>

--- a/frontend/app/components/header/HeaderUsersMenu.tsx
+++ b/frontend/app/components/header/HeaderUsersMenu.tsx
@@ -1,6 +1,5 @@
 import { Button, Menu } from '@mantine/core'
-import { FaUserFriends } from "react-icons/fa";
-import { FaUsers } from "react-icons/fa";
+import { FaUsers, FaUserFriends } from "react-icons/fa";
 import { FaUserPlus } from "react-icons/fa6";
 import { useNavigate } from '@remix-run/react';
 

--- a/frontend/app/components/layouts/FormLayout.tsx
+++ b/frontend/app/components/layouts/FormLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { UseFormReturnType } from '@mantine/form'
-import { Center, Paper, Stack } from '@mantine/core'
+import { Stack } from '@mantine/core'
 
 interface FormLayoutProps<T> {
   form: UseFormReturnType<T, (values: T) => T>

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "@remix-run/cloudflare";
+import { redirect, type MetaFunction } from "@remix-run/cloudflare";
 import { Text } from "@mantine/core";
 
 export const meta: MetaFunction = () => {
@@ -8,6 +8,6 @@ export const meta: MetaFunction = () => {
   ];
 };
 
-export default function Index() {
-  return (<Text>いずれログインページ(auth/login)にリダイレクトする予定のページ</Text>);
+export async function loader() {
+  return redirect('home')
 }

--- a/frontend/app/routes/home._index.tsx
+++ b/frontend/app/routes/home._index.tsx
@@ -6,17 +6,20 @@ import BookListComponent from '~/components/books/BookListComponent'
 import { useForm } from '@mantine/form'
 import { GetBooksParams } from 'orval/client.schemas'
 import { useDisclosure } from '@mantine/hooks'
+import { useAtom } from 'jotai'
+import { selectedBooksAtom } from '~/stores/cartAtom'
+import { useEffect } from 'react'
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url)
   const title = url.searchParams.get('title') ?? undefined
   const publisher = url.searchParams.get('publisher') ?? undefined
   const isbn = url.searchParams.get('isbn') ?? undefined
-  const auther = url.searchParams.get('author') ?? undefined
+  const author = url.searchParams.get('author') ?? undefined
   const page = url.searchParams.get('page') ?? undefined
   const limit = url.searchParams.get('limit') ?? undefined
-  const response = await getBooks({ title: title, author: auther, publisher: publisher, isbn: isbn, page: page, limit: limit })
-  return json({ booksResponse: response, title: title, author: auther, publisher: publisher, isbn: isbn, page: page, limit: limit })
+  const response = await getBooks({ title: title, author: author, publisher: publisher, isbn: isbn, page: page, limit: limit })
+  return json({ booksResponse: response, title: title, author: author, publisher: publisher, isbn: isbn, page: page, limit: limit })
 }
 
 const BooKListPage = () => {
@@ -31,6 +34,7 @@ const BooKListPage = () => {
   } = useLoaderData<typeof loader>()
   const [opened, { open, close }] = useDisclosure()
   const navigate = useNavigate()
+  const [, setSelectedBook] = useAtom(selectedBooksAtom)
   const form = useForm<GetBooksParams>({
     mode: 'uncontrolled',
     initialValues: {
@@ -40,7 +44,9 @@ const BooKListPage = () => {
       isbn: isbn ?? '',
     }
   })
-
+  useEffect(() => {
+    setSelectedBook([])
+  }, [])
 
   const handleSubmit = (props: GetBooksParams) => {
     let url = '/home'

--- a/frontend/app/routes/home._index.tsx
+++ b/frontend/app/routes/home._index.tsx
@@ -65,9 +65,6 @@ const BooKListPage = () => {
       url = (initial === true) ? `${url}?limit=${limit}` : `${url}&limit=${limit}`
       initial = false
     }
-    // 書籍一覧ページ(`/home`)に遷移すると、ヘッダーの部分がMainコンポーネントとして表示されてしまい、ページの頭に空白ができる。
-    // そのため、`/home#search-mode-button`に遷移することで、ヘッダーの部分が表示されないようにする。
-    url = `${url}#search-mode-button`
     navigate(url)
   }
 
@@ -95,9 +92,6 @@ const BooKListPage = () => {
       initial = false
     }
     url = (initial === true) ? `${url}?page=${newPage}` : `${url}&page=${newPage}`
-    // 書籍一覧ページ(`/home`)に遷移すると、ヘッダーの部分がMainコンポーネントとして表示されてしまい、ページの頭に空白ができる。
-    // そのため、`/home#search-mode-button`に遷移することで、ヘッダーの部分が表示されないようにする。
-    url = `${url}#search-mode-button`
     navigate(url)
   }
 
@@ -121,9 +115,6 @@ const BooKListPage = () => {
       initial = false
     }
     url = (initial === true) ? `${url}?limit=${newLimit}` : `${url}&limit=${newLimit}`
-    // 書籍一覧ページ(`/home`)に遷移すると、ヘッダーの部分がMainコンポーネントとして表示されてしまい、ページの頭に空白ができる。
-    // そのため、`/home#search-mode-button`に遷移することで、ヘッダーの部分が表示されないようにする。
-    url = `${url}#search-mode-button`
     navigate(url)
   }
 

--- a/frontend/app/routes/home._index.tsx
+++ b/frontend/app/routes/home._index.tsx
@@ -51,19 +51,19 @@ const BooKListPage = () => {
   const handleSubmit = (props: GetBooksParams) => {
     let url = '/home'
     let initial = true
-    if (props.title !== '') {
+    if (props.title && props.title !== '') {
       url = (initial === true) ? `${url}?title=${props.title}` : `${url}&title=${props.title}`
       initial = false
     }
-    if (props.author !== '') {
+    if (props.author && props.author !== '') {
       url = (initial === true) ? `${url}?author=${props.author}` : `${url}&author=${props.author}`
       initial = false
     }
-    if (props.publisher !== '') {
+    if (props.publisher && props.publisher !== '') {
       url = (initial === true) ? `${url}?publisher=${props.publisher}` : `${url}&publisher=${props.publisher}`
       initial = false
     }
-    if (props.isbn !== '') {
+    if (props.isbn && props.isbn !== '') {
       url = (initial === true) ? `${url}?isbn=${props.isbn}` : `${url}&isbn=${props.isbn}`
       initial = false
     }

--- a/frontend/app/routes/home._index.tsx
+++ b/frontend/app/routes/home._index.tsx
@@ -44,6 +44,8 @@ const BooKListPage = () => {
       isbn: isbn ?? '',
     }
   })
+
+  // 選択中の書籍をリセットする
   useEffect(() => {
     setSelectedBook([])
   }, [])

--- a/frontend/app/routes/home.books.$bookId.tsx
+++ b/frontend/app/routes/home.books.$bookId.tsx
@@ -1,13 +1,45 @@
-import { json } from '@remix-run/cloudflare'
-import type { LoaderFunctionArgs } from '@remix-run/cloudflare'
-import { getBook } from 'orval/client'
+import { json, redirect } from '@remix-run/cloudflare'
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/cloudflare'
+import { deleteBook, getBook } from 'orval/client'
 import { useLoaderData } from '@remix-run/react'
 import BookDetailComponent from '~/components/book-detail/BookDetailComponent'
+import { errorNotifications, successNotifications } from '~/utils/notification'
+import type { HeadersInit } from '@cloudflare/workers-types'
+
+interface Response {
+  method: string
+  status: number
+}
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const bookId = params.bookId ?? ''
   const response = await getBook(bookId)
   return json({ bookResponse: response })
+}
+
+export const action = async ({ request }: ActionFunctionArgs) => { // delete: 本の削除
+  const cookieHeader = request.headers.get('Cookie')
+  const formData = await request.formData()
+  if (request.method === "DELETE") {
+    const bookId = String(formData.get('bookId'))
+    const response = await deleteBook(bookId, { headers: { 'Cookie': cookieHeader ?? "" } })
+    switch (response.status) {
+      case 204:
+        successNotifications('削除しました')
+        return redirect('/home')
+      case 401:
+        errorNotifications('ログインしてください')
+        return redirect('/auth/login')
+      case 404:
+        errorNotifications('書籍が見つかりません')
+        return redirect('/home')
+      case 500:
+        errorNotifications('サーバーエラーが発生しました')
+        return json<Response>({ method: 'DELETE', status: 500 })
+    }
+  }
+
+  return null
 }
 
 const BookDetailPage = () => {

--- a/frontend/app/routes/home.books.$bookId.tsx
+++ b/frontend/app/routes/home.books.$bookId.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
 import { json } from '@remix-run/cloudflare'
 import type { LoaderFunctionArgs } from '@remix-run/cloudflare'
-import { getBook, getLoans } from 'orval/client'
+import { getBook } from 'orval/client'
 import { useLoaderData } from '@remix-run/react'
 import BookDetailComponent from '~/components/book-detail/BookDetailComponent'
 

--- a/frontend/app/routes/home.books.$bookId.tsx
+++ b/frontend/app/routes/home.books.$bookId.tsx
@@ -31,7 +31,7 @@ export const action = async ({ request }: ActionFunctionArgs) => { // delete: �
         errorNotifications('ログインしてください')
         return redirect('/auth/login')
       case 404:
-        errorNotifications('書籍が見つかりません')
+        errorNotifications('書籍が見つかりませんでした')
         return redirect('/home')
       case 500:
         errorNotifications('サーバーエラーが発生しました')

--- a/frontend/app/routes/home.books.$bookId.tsx
+++ b/frontend/app/routes/home.books.$bookId.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { json } from '@remix-run/cloudflare'
+import type { LoaderFunctionArgs } from '@remix-run/cloudflare'
+import { getBook, getLoans } from 'orval/client'
+import { useLoaderData } from '@remix-run/react'
+import BookDetailComponent from '~/components/book-detail/BookDetailComponent'
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  const bookId = params.bookId ?? ''
+  const response = await getBook(bookId)
+  return json({ bookResponse: response })
+}
+
+const BookDetailPage = () => {
+  const { bookResponse } = useLoaderData<typeof loader>()
+  return (
+    <BookDetailComponent
+      bookResponse={bookResponse}
+    />
+  )
+}
+
+export default BookDetailPage

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from '@remix-run/react'
-import { AppShell } from '@mantine/core'
+import { AppShell, Container } from '@mantine/core'
 import HeaderComponent from '~/components/header/HeaderComponent'
 
 const Home = () => {
@@ -9,9 +9,11 @@ const Home = () => {
       padding={{ default: 'md', sm: 'sm' }}
     >
       <HeaderComponent />
-      <AppShell.Main>
-        <Outlet />
-      </AppShell.Main>
+      <Container size='xl'>
+        <AppShell.Main>
+          <Outlet />
+        </AppShell.Main>
+      </Container>
     </AppShell>
   )
 }

--- a/frontend/app/stores/userAtom.ts
+++ b/frontend/app/stores/userAtom.ts
@@ -1,13 +1,7 @@
 import { createJSONStorage, atomWithStorage } from "jotai/utils";
 import type { User } from "orval/client.schemas";
 
-const storage = createJSONStorage<User>(() => sessionStorage)
-export const noUser: User = {
-  id: -1,
-  email: '',
-  name: '',
-  sessionToken: ''
-}
+const storage = createJSONStorage<User | undefined>(() => sessionStorage)
 
 // ユーザ情報を管理するAtom 生存時間: セッションストレージ(タブが閉じられるまで)
-export const userAtom = atomWithStorage<User>('user', noUser, storage);
+export const userAtom = atomWithStorage<User | undefined>('user', undefined, storage);

--- a/frontend/orval/client.schemas.ts
+++ b/frontend/orval/client.schemas.ts
@@ -33,8 +33,14 @@ export type UpsertLoansBodyItem = {
   volume: number;
 };
 
+export type GetLoans200LoansItem = {
+  books?: Book;
+  loans?: Loan;
+  users?: User;
+};
+
 export type GetLoans200 = {
-  loans: Loan[];
+  loans: GetLoans200LoansItem[];
   totalLoan: number;
 };
 


### PR DESCRIPTION
<!-- Closeするissue番号 -->
- Close #77 
- Close #73 
- Close #91 

## やったこと

- やったこと (コミットのハッシュ)
- `/home`でのヘッダー部分空白問題が解決したため、アンカーリンクを解除した f13a63809ad95db639a6324314aab5521336096d
- エラーコンポーネントを切り分けて再利用できるようにした。 a6e076d4ad953249e830afa39433fea80e97e297
- 本詳細ページの実装をした a6e076d4ad953249e830afa39433fea80e97e297
- [x] 本詳細ページにおいてボタンをクリックした際の関数を実装する [b874d0b](https://github.com/kitcc-org/kitcc-library/pull/85/commits/b874d0b94df1e8f7e692ca0d7534a3330d4c62c0)
- [x] 本詳細ページにおいて、その本を借りている人を表示するようにする。[b874d0b](https://github.com/kitcc-org/kitcc-library/pull/85/commits/b874d0b94df1e8f7e692ca0d7534a3330d4c62c0)
- #73 [3204880](https://github.com/kitcc-org/kitcc-library/pull/85/commits/3204880bf878bf39f40c55b212d8cd69a7a2eeab)
- #91 https://github.com/kitcc-org/kitcc-library/pull/85/commits/2e8249ae7ae4be549c32b822d83535d075786525

## 確認した方法

- `pnpm run dev`で、目視で確認
- 実際にdeleteボタンをクリックして、書籍一覧の数が減るか確認
- ランディングページにアクセスして、`/home`に遷移するか確認
- ログアウトした後、ログインボタンを押して、ログインページに遷移し、その後、`/home`ページにブラウザの戻るボタンで戻った時のUIを確認した。
- ログアウトした後にブラウザバックしてもログアウト用のUIが表示された


## スクリーンショット

| ログイン時 | ログアウト時 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/7c650433-d709-4798-8780-336c176d61d0) | ![image](https://github.com/user-attachments/assets/94b9fb4c-d74f-4f06-bf53-3618b33c8e3b) |

## 自動生成したコード

- `orval`直下
