### PR TITLE
customFetchにおけるメディアタイプの判定を修正する

### DIFF
--- a/frontend/orval/mutator.ts
+++ b/frontend/orval/mutator.ts
@@ -12,7 +12,7 @@ export const customFetch = async <T>(
   const response: { status: number; data?: unknown } = { status: res.status };
   const contentType = res.headers.get("content-type");
 
-  if (contentType === "application/json") {
+  if (contentType?.includes("application/json")) {
     response.data = await res.json();
   }
 


### PR DESCRIPTION
<!-- Closeするissue番号 -->
- Close #95 

## やったこと



## 確認した方法

フロントエンドとバックエンドのサーバを起動して書籍一覧ページにアクセス

`mutator.ts`での出力結果
```
{
  status: 200,
  data: {
    totalBook: 5,
    books: [ [Object], [Object], [Object], [Object], [Object] ]
  }
}
```



