### PR TITLE
69 book add page

### DIFF
--- a/frontend/app/components/book-detail/BookDetailControlButtons.tsx
+++ b/frontend/app/components/book-detail/BookDetailControlButtons.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import BookDetailEditButton from './BookDetailEditButton';
+import { MdDeleteForever } from 'react-icons/md';
+import { Button } from '@mantine/core';
+import { useFetcher } from '@remix-run/react';
+
+interface BookDetailControlButtonsProps {
+	id: number;
+}
+
+const BookDetailControlButtons = ({ id }: BookDetailControlButtonsProps) => {
+	const fetcher = useFetcher();
+	return (
+		<>
+			<BookDetailEditButton bookId={id} />
+			<Button
+				color="red"
+				leftSection={<MdDeleteForever />}
+				fz="lg"
+				onClick={() =>
+					fetcher.submit(
+						{ bookId: id },
+						{ action: '/home/books/$bookId', method: 'DELETE' },
+					)
+				}
+				disabled={fetcher.state === 'submitting'}
+			>
+				削除
+			</Button>
+		</>
+	);
+};
+
+export default BookDetailControlButtons;

--- a/frontend/app/components/book-detail/BookDetailControlButtons.tsx
+++ b/frontend/app/components/book-detail/BookDetailControlButtons.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import BookDetailEditButton from './BookDetailEditButton';
 import { MdDeleteForever } from 'react-icons/md';
 import { Button } from '@mantine/core';

--- a/frontend/app/components/book-detail/BookDetailControlPanel.tsx
+++ b/frontend/app/components/book-detail/BookDetailControlPanel.tsx
@@ -1,22 +1,27 @@
-import { Button, Stack } from '@mantine/core';
-import { useFetcher } from '@remix-run/react';
+import { Stack } from '@mantine/core';
 import { useAtom } from 'jotai';
-import { MdDeleteForever } from 'react-icons/md';
 import { userAtom } from '~/stores/userAtom';
-import BookDetailEditButton from './BookDetailEditButton';
 import BookDetailThumbnail from './BookDetailThumbnail';
+import BookDetailControlButtons from './BookDetailControlButtons';
+import { useLocation } from '@remix-run/react';
+import GlobalBookDetailControlButtons from '../global-book-detail/GlobalBookDetailControlButtons';
+import { SearchBooks200BooksItem } from 'client/client.schemas';
 
 interface BookDetailControlPanelProps {
-	id: number;
+	id?: number;
 	thumbnail?: string;
+	searchBook?: SearchBooks200BooksItem;
+	totalBook?: number;
 }
 
 const BookDetailControlPanel = ({
 	id,
 	thumbnail,
+	searchBook,
+	totalBook,
 }: BookDetailControlPanelProps) => {
 	const [user] = useAtom(userAtom);
-	const fetcher = useFetcher();
+	const location = useLocation();
 
 	return (
 		<Stack
@@ -26,23 +31,15 @@ const BookDetailControlPanel = ({
 			gap="md"
 		>
 			<BookDetailThumbnail thumbnail={thumbnail} />
-			{!!user && <BookDetailEditButton bookId={id} />}
-			{!!user && (
-				<Button
-					color="red"
-					leftSection={<MdDeleteForever />}
-					fz="lg"
-					onClick={() =>
-						fetcher.submit(
-							{ bookId: id },
-							{ action: '/home/books/$bookId', method: 'DELETE' },
-						)
-					}
-					disabled={fetcher.state === 'submitting'}
-				>
-					削除
-				</Button>
-			)}
+			{user && location.pathname.includes('global')
+				? searchBook &&
+					totalBook && (
+						<GlobalBookDetailControlButtons
+							searchBook={searchBook}
+							totalBook={totalBook}
+						/>
+					)
+				: id && <BookDetailControlButtons id={id} />}
 		</Stack>
 	);
 };

--- a/frontend/app/components/global-book-detail/GlobalBookDetailAuthorBadge.tsx
+++ b/frontend/app/components/global-book-detail/GlobalBookDetailAuthorBadge.tsx
@@ -1,0 +1,24 @@
+import { Badge } from '@mantine/core';
+
+interface GlobalBookDetailAuthorBadgeProps {
+	name: string;
+}
+
+const GlobalBookDetailAuthorBadge = ({
+	name,
+}: GlobalBookDetailAuthorBadgeProps) => {
+	return (
+		<Badge
+			component="a"
+			color="teal"
+			href={`/home/global?author=${name}`}
+			style={{ cursor: 'pointer' }}
+			variant="outline"
+			size="lg"
+		>
+			{name}
+		</Badge>
+	);
+};
+
+export default GlobalBookDetailAuthorBadge;

--- a/frontend/app/components/global-book-detail/GlobalBookDetailContent.tsx
+++ b/frontend/app/components/global-book-detail/GlobalBookDetailContent.tsx
@@ -1,0 +1,32 @@
+import { Stack } from '@mantine/core';
+import { SearchBooks200BooksItem } from 'client/client.schemas';
+import GlobalBookDetailContentTable from './GlobalBookDetailContentTable';
+import BookDetailTitle from '../book-detail/BookDetailTitle';
+import BookDetailDescription from '../book-detail/BookDetailDescription';
+import GlobalBookDetailLink from './GlobalBookDetailLink';
+
+interface GlobalBookDetailContentProps {
+	book: SearchBooks200BooksItem;
+	bookId: number;
+}
+
+const GlobalBookDetailContent = ({
+	book,
+	bookId,
+}: GlobalBookDetailContentProps) => {
+	return (
+		<Stack
+			bg="var(--mantine-color-body)"
+			align="stretch"
+			justify="flex-start"
+			gap="xl"
+		>
+			<BookDetailTitle title={book.title} />
+			<GlobalBookDetailContentTable book={book} />
+			<BookDetailDescription description={book.description ?? ''} />
+			{bookId > 0 && <GlobalBookDetailLink bookId={bookId} />}
+		</Stack>
+	);
+};
+
+export default GlobalBookDetailContent;

--- a/frontend/app/components/global-book-detail/GlobalBookDetailContentTable.tsx
+++ b/frontend/app/components/global-book-detail/GlobalBookDetailContentTable.tsx
@@ -1,0 +1,43 @@
+import { Group, rem, Stack, Table, Text } from '@mantine/core';
+import { SearchBooks200BooksItem } from 'client/client.schemas';
+import GlobalBookDetailAuthorBadge from './GlobalBookDetailAuthorBadge';
+
+interface GlobalBookDetailContentTableProps {
+	book: SearchBooks200BooksItem;
+}
+
+const GlobalBookDetailContentTable = ({
+	book,
+}: GlobalBookDetailContentTableProps) => {
+	return (
+		<Stack gap="sm" align="stretch" justify="flex-start">
+			<Text fz={rem(22)}>書籍情報</Text>
+			<Table fz={rem(17)}>
+				<Table.Tr key={'author'}>
+					<Table.Th>著者</Table.Th>
+					<Table.Td>
+						<Group gap={rem(7)}>
+							{book.authors.map((author, id) => (
+								<GlobalBookDetailAuthorBadge key={id} name={author} />
+							))}
+						</Group>
+					</Table.Td>
+				</Table.Tr>
+				<Table.Tr key={'publisher'}>
+					<Table.Th>出版社</Table.Th>
+					<Table.Td>{book.publisher}</Table.Td>
+				</Table.Tr>
+				<Table.Tr key={'publishedDate'}>
+					<Table.Th>出版日</Table.Th>
+					<Table.Td>{book.publishedDate}</Table.Td>
+				</Table.Tr>
+				<Table.Tr key={'isbn'}>
+					<Table.Th>ISBN</Table.Th>
+					<Table.Td>{book.isbn}</Table.Td>
+				</Table.Tr>
+			</Table>
+		</Stack>
+	);
+};
+
+export default GlobalBookDetailContentTable;

--- a/frontend/app/components/global-book-detail/GlobalBookDetailControlButtons.tsx
+++ b/frontend/app/components/global-book-detail/GlobalBookDetailControlButtons.tsx
@@ -1,0 +1,44 @@
+import { Button } from '@mantine/core';
+import { useFetcher } from '@remix-run/react';
+import { CreateBookBody, SearchBooks200BooksItem } from 'client/client.schemas';
+import { BiSolidBookAdd } from 'react-icons/bi';
+
+interface GlobalBookDetailControlButtonsProps {
+	searchBook: SearchBooks200BooksItem;
+	totalBook: number;
+}
+
+const GlobalBookDetailControlButtons = ({
+	searchBook,
+	totalBook,
+}: GlobalBookDetailControlButtonsProps) => {
+	const fetcher = useFetcher<CreateBookBody>();
+	const addBookData: CreateBookBody = {
+		authors: searchBook.authors,
+		description: searchBook.description ?? '',
+		isbn: searchBook.isbn ?? '',
+		publishedDate: searchBook.publishedDate ?? '',
+		publisher: searchBook.publisher ?? '',
+		stock: 1,
+		thumbnail: searchBook.thumbnail,
+		title: searchBook.title,
+	};
+	return (
+		<Button
+			variant="filled"
+			color="teal"
+			disabled={totalBook > 0}
+			leftSection={<BiSolidBookAdd />}
+			onCanPlay={() =>
+				fetcher.submit(addBookData, {
+					action: '/home/global/books/$bookId',
+					method: 'POST',
+				})
+			}
+		>
+			{totalBook > 0 ? '追加済み' : '追加'}
+		</Button>
+	);
+};
+
+export default GlobalBookDetailControlButtons;

--- a/frontend/app/components/global-book-detail/GlobalBookDetailLink.tsx
+++ b/frontend/app/components/global-book-detail/GlobalBookDetailLink.tsx
@@ -1,0 +1,16 @@
+import { Anchor, Text } from '@mantine/core';
+
+interface GlobalBookDetailLinkProps {
+	bookId: number;
+}
+
+const GlobalBookDetailLink = ({ bookId }: GlobalBookDetailLinkProps) => {
+	return (
+		<Text>
+			この書籍はすでに登録されています。蔵書の詳細ページは
+			<Anchor href={`/home/books/${bookId}`}>こちら</Anchor>
+		</Text>
+	);
+};
+
+export default GlobalBookDetailLink;

--- a/frontend/app/components/global-books/GlobalBookCard.tsx
+++ b/frontend/app/components/global-books/GlobalBookCard.tsx
@@ -11,7 +11,8 @@ const GlobalBookCard = ({ book }: GlobalBookCardProps) => {
 		<Card shadow="sm" radius="md" pb="xs" withBorder>
 			<Card.Section withBorder inheritPadding py="xs">
 				<BookCardThumbnail
-					id={book.isbn ? Number(book.isbn) : undefined}
+					// Google Books APIでisbnの味の検索ができるまではコメントアウト
+					// id={book.isbn ? Number(book.isbn) : undefined}
 					thumbnail={book.thumbnail}
 				/>
 			</Card.Section>

--- a/frontend/app/routes/home._index/route.tsx
+++ b/frontend/app/routes/home._index/route.tsx
@@ -26,7 +26,7 @@ interface LoaderData {
 	};
 }
 
-interface ActionResponse {
+export interface ActionResponse {
 	method: string;
 	status: number;
 }

--- a/frontend/app/routes/home.global.books.$isbn/route.tsx
+++ b/frontend/app/routes/home.global.books.$isbn/route.tsx
@@ -1,0 +1,131 @@
+import { Grid, rem, Stack } from '@mantine/core';
+import {
+	ActionFunctionArgs,
+	json,
+	LoaderFunctionArgs,
+	redirect,
+} from '@remix-run/cloudflare';
+import { useLoaderData } from '@remix-run/react';
+import {
+	createBook,
+	getBooks,
+	searchBooks,
+	searchBooksResponse,
+} from 'client/client';
+import { CreateBookBody } from 'client/client.schemas';
+import BookDetailControlPanel from '~/components/book-detail/BookDetailControlPanel';
+import GlobalBookDetailContent from '~/components/global-book-detail/GlobalBookDetailContent';
+import { commitSession, getSession } from '~/services/session.server';
+import { ActionResponse } from '../home._index/route';
+
+interface LoaderData {
+	searchBooksResponse: searchBooksResponse;
+	storageTotalBook: number;
+	bookId: number;
+}
+
+export const loader = async ({ params, request }: LoaderFunctionArgs) => {
+	const session = await getSession(request.headers.get('Cookie'));
+	// 書籍の情報を取得する
+	const isbn = params.isbn ?? '';
+	console.log('isbn', isbn);
+	const searchBooksResponse = await searchBooks({ isbn: isbn });
+	console.log('ここでは', searchBooksResponse);
+
+	// 蔵書追加処理実装をするため蔵書の情報を取得する
+	if (session.has('userId')) {
+		const getBookResponse = await getBooks({ isbn: isbn });
+		if (getBookResponse.data.totalBook > 0) {
+			return json<LoaderData>({
+				searchBooksResponse: searchBooksResponse,
+				storageTotalBook: getBookResponse.data.totalBook,
+				bookId: getBookResponse.data.books[0].id,
+			});
+		} else {
+			return json<LoaderData>({
+				searchBooksResponse: searchBooksResponse,
+				storageTotalBook: getBookResponse.data.totalBook,
+				bookId: -1,
+			});
+		}
+	} else {
+		// ログイン済みでない場合は、APIを呼び出す回数を減らすために蔵書の情報を取得しない
+		return json<LoaderData>({
+			searchBooksResponse: searchBooksResponse,
+			storageTotalBook: -1,
+			bookId: -1,
+		});
+	}
+};
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+	const session = await getSession(request.headers.get('Cookie'));
+
+	// 未ログインの場合
+	if (!session.has('userId')) {
+		session.flash('error', 'ログインしてください');
+		return redirect('/login', {
+			headers: {
+				'Set-Cookie': await commitSession(session),
+			},
+		});
+	}
+
+	const cookieHeader = [
+		`__Secure-user_id=${session.get('userId')};`,
+		`__Secure-session_token=${session.get('sessionToken')}`,
+	].join('; ');
+
+	const requestBody = await request.json<CreateBookBody>();
+
+	const response = await createBook(requestBody, {
+		headers: { Cookie: cookieHeader },
+	});
+
+	switch (response.status) {
+		case 201:
+			session.flash('success', '書籍を追加しました');
+			return redirect('/home', {
+				headers: { 'Set-Cookie': await commitSession(session) },
+			});
+		case 400:
+			session.flash('error', 'リクエストの中身が誤っています');
+			return json<ActionResponse>(
+				{ method: 'POST', status: response.status },
+				{ headers: { 'Set-Cookie': await commitSession(session) } },
+			);
+		case 401:
+			session.flash('error', 'ログインしてください');
+			return redirect('/login', {
+				headers: {
+					'Set-Cookie': await commitSession(session),
+				},
+			});
+	}
+};
+
+const GlobalBookDetailPage = () => {
+	const { searchBooksResponse, storageTotalBook, bookId } =
+		useLoaderData<LoaderData>();
+	return (
+		<Stack bg="var(--mantine-color-body)" align="stretch" justify="flex-start">
+			<Grid gutter={rem(50)}>
+				<Grid.Col span={3}>
+					<BookDetailControlPanel
+						thumbnail={searchBooksResponse.data.books[0].thumbnail}
+						searchBook={searchBooksResponse.data.books[0]}
+						totalBook={storageTotalBook}
+					/>
+				</Grid.Col>
+				<Grid.Col span={9}>
+					<GlobalBookDetailContent
+						book={searchBooksResponse.data.books[0]}
+						bookId={bookId}
+					/>
+				</Grid.Col>
+			</Grid>
+		</Stack>
+	);
+};
+
+export default GlobalBookDetailPage;


### PR DESCRIPTION
<!-- Closeするissue番号 -->
- Close #69 

## やったこと

- やったこと (コミットのハッシュ)
- 詳細ページの左側を再利用できるように書き換えた de8b5565461d1e9dbf380782b4861a7653f056ec
- グローバル検索での詳細ページを実装した ee57df8fe4cef74de516f23f49dc30ecf9c9c8e4
- actionでレスポンスを返せるよう、レスポンスの型を参照できるようにした b8dc79c21950c97c9aee1d7ae489ed215d5a2f86
- isbnのみでのGoogle Books APIが動かないので、詳細ページを開かないようにした 3260d34bf595cc1d43cae7d2bd807af15ae1eb9c

## 確認した方法

`pnpm run dev`


## スクリーンショット

- 開けないのでなし


## 自動生成したコード

- ファイル名
