### PR TITLE
ユーザー一覧の実装

### DIFF
--- a/frontend/app/components/book-detail/BookDetailControlButtons.tsx
+++ b/frontend/app/components/book-detail/BookDetailControlButtons.tsx
@@ -1,7 +1,4 @@
 import BookDetailEditButton from './BookDetailEditButton';
-import { MdDeleteForever } from 'react-icons/md';
-import { Button } from '@mantine/core';
-import { useFetcher } from '@remix-run/react';
 import BookDetailDeleteButton from './BookDetailDeleteButton';
 
 interface BookDetailControlButtonsProps {

--- a/frontend/app/components/book-detail/BookDetailDeleteButton.tsx
+++ b/frontend/app/components/book-detail/BookDetailDeleteButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MdDeleteForever } from 'react-icons/md';
 import { Button } from '@mantine/core';
 import { useFetcher } from '@remix-run/react';

--- a/frontend/app/components/books/BookListComponent.tsx
+++ b/frontend/app/components/books/BookListComponent.tsx
@@ -43,7 +43,7 @@ const BookListComponent = ({
 			<ContentsHeader
 				page={paginationProps.page}
 				limit={paginationProps.limit}
-				total={paginationProps.totalNum}
+				total={paginationProps.total}
 				handleLimitChange={paginationProps.handleLimitChange}
 			/>
 			{booksResponse.status !== 200 ? (
@@ -52,7 +52,7 @@ const BookListComponent = ({
 				<BookCards books={booksResponse.data.books} />
 			)}
 			<PaginationComponent
-				totalNum={paginationProps.totalNum}
+				total={paginationProps.total}
 				page={paginationProps.page}
 				limit={paginationProps.limit}
 				handlePaginationChange={paginationProps.handlePaginationChange}

--- a/frontend/app/components/books/BookListComponent.tsx
+++ b/frontend/app/components/books/BookListComponent.tsx
@@ -7,6 +7,7 @@ import ErrorComponent from '../common/error/ErrorComponent';
 import ContentsHeader from '../common/pagination/ContentsHeader';
 import PaginationComponent from '../common/pagination/PaginationComponent';
 import BookCards from './BookCards';
+import { PaginationProps } from '~/types/paginatiion';
 
 interface BookListComponentProps {
 	booksResponse: getBooksResponse;
@@ -18,11 +19,7 @@ interface BookListComponentProps {
 	isOpen: boolean;
 	open: () => void;
 	close: () => void;
-	handlePaginationChange: (newPage: number) => void;
-	handleLimitChange: (newLimit: number) => void;
-	page?: number;
-	limit?: number;
-	totalBook: number;
+	paginationProps: PaginationProps;
 }
 
 const BookListComponent = ({
@@ -32,11 +29,7 @@ const BookListComponent = ({
 	isOpen,
 	open,
 	close,
-	handlePaginationChange,
-	handleLimitChange,
-	page,
-	limit,
-	totalBook,
+	paginationProps,
 }: BookListComponentProps) => {
 	return (
 		<Stack bg="var(--mantine-color-body)" align="stretch" justify="flex-start">
@@ -48,10 +41,10 @@ const BookListComponent = ({
 				handleSubmit={handleSubmit}
 			/>
 			<ContentsHeader
-				page={page}
-				limit={limit}
-				total={totalBook}
-				handleLimitChange={handleLimitChange}
+				page={paginationProps.page}
+				limit={paginationProps.limit}
+				total={paginationProps.totalNum}
+				handleLimitChange={paginationProps.handleLimitChange}
 			/>
 			{booksResponse.status !== 200 ? (
 				<ErrorComponent message={'書籍情報を取得できませんでした。'} />
@@ -59,10 +52,10 @@ const BookListComponent = ({
 				<BookCards books={booksResponse.data.books} />
 			)}
 			<PaginationComponent
-				totalNum={totalBook}
-				page={page}
-				limit={limit}
-				handlePaginationChange={handlePaginationChange}
+				totalNum={paginationProps.totalNum}
+				page={paginationProps.page}
+				limit={paginationProps.limit}
+				handlePaginationChange={paginationProps.handlePaginationChange}
 			/>
 		</Stack>
 	);

--- a/frontend/app/components/common/pagination/PaginationComponent.tsx
+++ b/frontend/app/components/common/pagination/PaginationComponent.tsx
@@ -1,7 +1,7 @@
 import { Center, Pagination } from '@mantine/core';
 
 interface PaginationComponentProps {
-	totalNum: number;
+	total: number;
 	page?: number;
 	limit?: number;
 	handlePaginationChange: (newPage: number) => void;
@@ -9,14 +9,14 @@ interface PaginationComponentProps {
 }
 
 const PaginationComponent = ({
-	totalNum,
+	total,
 	page,
 	limit,
 	handlePaginationChange,
 	color,
 }: PaginationComponentProps) => {
 	const limitNum = limit ?? 10;
-	const totalPage = totalNum / limitNum + 1;
+	const totalPage = total / limitNum + 1;
 	return (
 		<Center>
 			<Pagination

--- a/frontend/app/components/common/pagination/PaginationComponent.tsx
+++ b/frontend/app/components/common/pagination/PaginationComponent.tsx
@@ -16,7 +16,7 @@ const PaginationComponent = ({
 	color,
 }: PaginationComponentProps) => {
 	const limitNum = limit ?? 10;
-	const totalPage = total / limitNum + 1;
+	const totalPage = total != 0 ? Math.ceil(total / limitNum) : 1;
 	return (
 		<Center>
 			<Pagination

--- a/frontend/app/components/global-books/GlobalBookListComponent.tsx
+++ b/frontend/app/components/global-books/GlobalBookListComponent.tsx
@@ -9,18 +9,11 @@ import ErrorComponent from '../common/error/ErrorComponent';
 import GlobalBookCards from './GlobalBookCards';
 import GlobalBookSearchComponent from './GlobalBookSearchComponent';
 import PaginationComponent from '../common/pagination/PaginationComponent';
+import { PaginationProps } from '~/types/paginatiion';
 
 export interface HandleGlobalSearchFunctions {
 	handleDetailSubmit: (props: SearchBooksParams) => void;
 	handleKeywordSubmit: (props: SearchBooksParams) => void;
-}
-
-interface HandlePaginationProps {
-	handlePaginationChange: (newPage: number) => void;
-	handleLimitChange: (newLimit: number) => void;
-	page?: number;
-	limit?: number;
-	totalBook: number;
 }
 
 interface GlobalBookListComponentProps {
@@ -30,7 +23,7 @@ interface GlobalBookListComponentProps {
 		(values: SearchBooksParams) => SearchBooksParams
 	>;
 	globalSearchFunctions: HandleGlobalSearchFunctions;
-	paginationProps: HandlePaginationProps;
+	paginationProps: PaginationProps;
 	isOpen: boolean;
 	open: () => void;
 	close: () => void;
@@ -63,7 +56,7 @@ const GlobalBookListComponent = ({
 			<ContentsHeader
 				page={paginationProps.page}
 				limit={paginationProps.limit}
-				total={paginationProps.totalBook}
+				total={paginationProps.totalNum}
 				handleLimitChange={paginationProps.handleLimitChange}
 			/>
 			{!booksResponse ? (
@@ -74,7 +67,7 @@ const GlobalBookListComponent = ({
 				<GlobalBookCards books={booksResponse.data.books} />
 			)}
 			<PaginationComponent
-				totalNum={paginationProps.totalBook}
+				totalNum={paginationProps.totalNum}
 				page={paginationProps.page}
 				limit={paginationProps.limit}
 				handlePaginationChange={paginationProps.handlePaginationChange}

--- a/frontend/app/components/global-books/GlobalBookListComponent.tsx
+++ b/frontend/app/components/global-books/GlobalBookListComponent.tsx
@@ -56,7 +56,7 @@ const GlobalBookListComponent = ({
 			<ContentsHeader
 				page={paginationProps.page}
 				limit={paginationProps.limit}
-				total={paginationProps.totalNum}
+				total={paginationProps.total}
 				handleLimitChange={paginationProps.handleLimitChange}
 			/>
 			{!booksResponse ? (
@@ -67,7 +67,7 @@ const GlobalBookListComponent = ({
 				<GlobalBookCards books={booksResponse.data.books} />
 			)}
 			<PaginationComponent
-				totalNum={paginationProps.totalNum}
+				total={paginationProps.total}
 				page={paginationProps.page}
 				limit={paginationProps.limit}
 				handlePaginationChange={paginationProps.handlePaginationChange}

--- a/frontend/app/components/users/NoUserComponent.tsx
+++ b/frontend/app/components/users/NoUserComponent.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Blockquote, Center } from '@mantine/core';
+import { Blockquote, Center } from '@mantine/core';
 import { FaInfoCircle } from 'react-icons/fa';
 
 interface NoUserComponentProps {

--- a/frontend/app/components/users/NoUserComponent.tsx
+++ b/frontend/app/components/users/NoUserComponent.tsx
@@ -1,0 +1,18 @@
+import { Anchor, Blockquote, Center } from '@mantine/core';
+import { FaInfoCircle } from 'react-icons/fa';
+
+interface NoUserComponentProps {
+	color?: string;
+}
+
+const NoUserComponent = ({ color }: NoUserComponentProps) => {
+	return (
+		<Center h="70dh" w="100%">
+			<Blockquote color={color ?? 'blue'} icon={<FaInfoCircle />} mt="xl">
+				ユーザーが存在しません。
+			</Blockquote>
+		</Center>
+	);
+};
+
+export default NoUserComponent;

--- a/frontend/app/components/users/UserAddButton.tsx
+++ b/frontend/app/components/users/UserAddButton.tsx
@@ -1,0 +1,19 @@
+import { Button } from '@mantine/core';
+import { RiUserAddFill } from 'react-icons/ri';
+
+const UserAddButton = () => {
+	return (
+		<Button
+			color="blue"
+			variant="filled"
+			radius="xl"
+			leftSection={<RiUserAddFill />}
+			component="a"
+			href="users/add"
+		>
+			ユーザー追加
+		</Button>
+	);
+};
+
+export default UserAddButton;

--- a/frontend/app/components/users/UserDeleteButton.tsx
+++ b/frontend/app/components/users/UserDeleteButton.tsx
@@ -1,0 +1,24 @@
+import { Button } from '@mantine/core';
+
+interface UserDeleteButtonProps {
+	id: number;
+	handleDeleteUserButtonClick: (id: number) => void;
+}
+
+const UserDeleteButton = ({
+	id,
+	handleDeleteUserButtonClick,
+}: UserDeleteButtonProps) => {
+	return (
+		<Button
+			color="red"
+			variant="light"
+			bd="solid 2px"
+			onClick={() => handleDeleteUserButtonClick(id)}
+		>
+			削除
+		</Button>
+	);
+};
+
+export default UserDeleteButton;

--- a/frontend/app/components/users/UsersListComponent.tsx
+++ b/frontend/app/components/users/UsersListComponent.tsx
@@ -6,6 +6,7 @@ import PaginationComponent from '../common/pagination/PaginationComponent';
 import ErrorComponent from '../common/error/ErrorComponent';
 import { getUsersResponse } from 'client/client';
 import UsersListTable from './UsersListTable';
+import UserAddButton from './UserAddButton';
 
 interface UsersListComponentProps {
 	paginationProps: PaginationProps;
@@ -41,6 +42,7 @@ const UsersListComponent = ({
 				) : (
 					<ErrorComponent message={'ユーザー情報を取得できませんでした。'} />
 				)}
+				<UserAddButton />
 				<PaginationComponent
 					totalNum={paginationProps.totalNum}
 					page={paginationProps.page}

--- a/frontend/app/components/users/UsersListComponent.tsx
+++ b/frontend/app/components/users/UsersListComponent.tsx
@@ -1,0 +1,55 @@
+import { Container, Stack } from '@mantine/core';
+import UsersListTitle from './UsersListTitle';
+import ContentsHeader from '../common/pagination/ContentsHeader';
+import type { PaginationProps } from '~/types/paginatiion';
+import PaginationComponent from '../common/pagination/PaginationComponent';
+import ErrorComponent from '../common/error/ErrorComponent';
+import { getUsersResponse } from 'client/client';
+import UsersListTable from './UsersListTable';
+
+interface UsersListComponentProps {
+	paginationProps: PaginationProps;
+	usersResponse: getUsersResponse;
+	handleDeleteUserButtonClick: (id: number) => void;
+}
+
+const UsersListComponent = ({
+	paginationProps,
+	usersResponse,
+	handleDeleteUserButtonClick,
+}: UsersListComponentProps) => {
+	return (
+		<Container>
+			<Stack
+				bg="var(--mantine-color-body)"
+				align="center"
+				justify="center"
+				maw="100%"
+			>
+				<UsersListTitle />
+				<ContentsHeader
+					page={paginationProps.page}
+					limit={paginationProps.limit}
+					total={paginationProps.totalNum}
+					handleLimitChange={paginationProps.handleLimitChange}
+				/>
+				{usersResponse.status === 200 ? (
+					<UsersListTable
+						users={usersResponse.data.users}
+						handleDeleteUserButtonClick={handleDeleteUserButtonClick}
+					/>
+				) : (
+					<ErrorComponent message={'ユーザー情報を取得できませんでした。'} />
+				)}
+				<PaginationComponent
+					totalNum={paginationProps.totalNum}
+					page={paginationProps.page}
+					limit={paginationProps.limit}
+					handlePaginationChange={paginationProps.handlePaginationChange}
+				/>
+			</Stack>
+		</Container>
+	);
+};
+
+export default UsersListComponent;

--- a/frontend/app/components/users/UsersListComponent.tsx
+++ b/frontend/app/components/users/UsersListComponent.tsx
@@ -31,7 +31,7 @@ const UsersListComponent = ({
 				<ContentsHeader
 					page={paginationProps.page}
 					limit={paginationProps.limit}
-					total={paginationProps.totalNum}
+					total={paginationProps.total}
 					handleLimitChange={paginationProps.handleLimitChange}
 				/>
 				{usersResponse.status === 200 ? (
@@ -44,7 +44,7 @@ const UsersListComponent = ({
 				)}
 				<UserAddButton />
 				<PaginationComponent
-					totalNum={paginationProps.totalNum}
+					total={paginationProps.total}
 					page={paginationProps.page}
 					limit={paginationProps.limit}
 					handlePaginationChange={paginationProps.handlePaginationChange}

--- a/frontend/app/components/users/UsersListTable.tsx
+++ b/frontend/app/components/users/UsersListTable.tsx
@@ -1,0 +1,37 @@
+import { rem, Table } from '@mantine/core';
+import { GetUsers200UsersItem } from 'client/client.schemas';
+import UserDeleteButton from './UserDeleteButton';
+
+interface UsersTableProps {
+	users: GetUsers200UsersItem[];
+	handleDeleteUserButtonClick: (id: number) => void;
+}
+
+const UsersListTable = ({
+	users,
+	handleDeleteUserButtonClick,
+}: UsersTableProps) => {
+	return (
+		<Table striped maw="50%">
+			<Table.Tbody>
+				{users.map((user) => (
+					<Table.Tr key={user.id}>
+						{user.id && (
+							<>
+								<Table.Td>{user.name}</Table.Td>
+								<Table.Td maw={rem(5)}>
+									<UserDeleteButton
+										id={user.id}
+										handleDeleteUserButtonClick={handleDeleteUserButtonClick}
+									/>
+								</Table.Td>
+							</>
+						)}
+					</Table.Tr>
+				))}
+			</Table.Tbody>
+		</Table>
+	);
+};
+
+export default UsersListTable;

--- a/frontend/app/components/users/UsersListTable.tsx
+++ b/frontend/app/components/users/UsersListTable.tsx
@@ -1,6 +1,7 @@
 import { rem, Table } from '@mantine/core';
 import { GetUsers200UsersItem } from 'client/client.schemas';
 import UserDeleteButton from './UserDeleteButton';
+import NoUserComponent from './NoUserComponent';
 
 interface UsersTableProps {
 	users: GetUsers200UsersItem[];
@@ -11,6 +12,7 @@ const UsersListTable = ({
 	users,
 	handleDeleteUserButtonClick,
 }: UsersTableProps) => {
+	if (users.length === 0) return <NoUserComponent />;
 	return (
 		<Table striped maw="50%">
 			<Table.Tbody>

--- a/frontend/app/components/users/UsersListTitle.tsx
+++ b/frontend/app/components/users/UsersListTitle.tsx
@@ -1,0 +1,15 @@
+import { Center, Group, Title } from '@mantine/core';
+import { FaUsers } from 'react-icons/fa';
+
+const UsersListTitle = () => {
+	return (
+		<Center>
+			<Group justify="center" align="center">
+				<FaUsers size="3.5ch" />
+				<Title order={1}>ユーザー一覧</Title>
+			</Group>
+		</Center>
+	);
+};
+
+export default UsersListTitle;

--- a/frontend/app/routes/home._index/route.tsx
+++ b/frontend/app/routes/home._index/route.tsx
@@ -13,6 +13,7 @@ import { useEffect } from 'react';
 import BookListComponent from '~/components/books/BookListComponent';
 import { commitSession, getSession } from '~/services/session.server';
 import { SelectedBookProps, selectedBooksAtom } from '~/stores/bookAtom';
+import { ActionResponse } from '~/types/response';
 
 interface LoaderData {
 	booksResponse: getBooksResponse;
@@ -24,11 +25,6 @@ interface LoaderData {
 		page?: string;
 		limit?: string;
 	};
-}
-
-export interface ActionResponse {
-	method: string;
-	status: number;
 }
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
@@ -263,11 +259,13 @@ const BooKListPage = () => {
 			isOpen={opened}
 			open={open}
 			close={close}
-			handlePaginationChange={handlePaginationChange}
-			handleLimitChange={handleLimitChange}
-			page={page ? Number(page) : undefined}
-			limit={limit ? Number(limit) : undefined}
-			totalBook={booksResponse.data.totalBook}
+			paginationProps={{
+				handlePaginationChange: handlePaginationChange,
+				handleLimitChange: handleLimitChange,
+				page: page ? Number(page) : undefined,
+				limit: limit ? Number(limit) : undefined,
+				totalNum: booksResponse.data.totalBook,
+			}}
 		/>
 	);
 };

--- a/frontend/app/routes/home._index/route.tsx
+++ b/frontend/app/routes/home._index/route.tsx
@@ -264,7 +264,7 @@ const BooKListPage = () => {
 				handleLimitChange: handleLimitChange,
 				page: page ? Number(page) : undefined,
 				limit: limit ? Number(limit) : undefined,
-				totalNum: booksResponse.data.totalBook,
+				total: booksResponse.data.totalBook,
 			}}
 		/>
 	);

--- a/frontend/app/routes/home.books.$bookId/route.tsx
+++ b/frontend/app/routes/home.books.$bookId/route.tsx
@@ -12,15 +12,11 @@ import { commitSession, getSession } from '~/services/session.server';
 import { Book } from 'client/client.schemas';
 import BookDetailControlPanel from '~/components/book-detail/BookDetailControlPanel';
 import ErrorComponent from '~/components/common/error/ErrorComponent';
+import { ActionResponse } from '~/types/response';
 
 interface LoaderData {
 	bookResponse: getBookResponse;
 	loansResponse?: getLoansResponse;
-}
-
-interface ActionResponse {
-	method: string;
-	status: number;
 }
 
 export interface BookDetailOutletContext {

--- a/frontend/app/routes/home.global._index/route.tsx
+++ b/frontend/app/routes/home.global._index/route.tsx
@@ -270,7 +270,7 @@ const GlobalBookListPage = () => {
 				handleLimitChange: handleLimitChange,
 				page: page ? Number(page) : undefined,
 				limit: limit ? Number(limit) : undefined,
-				totalBook: booksResponse ? booksResponse.data.totalBook : 0,
+				totalNum: booksResponse ? booksResponse.data.totalBook : 0,
 			}}
 			searchMode={searchMode}
 			setSearchMode={setSearchMode}

--- a/frontend/app/routes/home.global._index/route.tsx
+++ b/frontend/app/routes/home.global._index/route.tsx
@@ -270,7 +270,7 @@ const GlobalBookListPage = () => {
 				handleLimitChange: handleLimitChange,
 				page: page ? Number(page) : undefined,
 				limit: limit ? Number(limit) : undefined,
-				totalNum: booksResponse ? booksResponse.data.totalBook : 0,
+				total: booksResponse ? booksResponse.data.totalBook : 0,
 			}}
 			searchMode={searchMode}
 			setSearchMode={setSearchMode}

--- a/frontend/app/routes/home.global.books.$isbn/route.tsx
+++ b/frontend/app/routes/home.global.books.$isbn/route.tsx
@@ -16,7 +16,7 @@ import { CreateBookBody } from 'client/client.schemas';
 import BookDetailControlPanel from '~/components/book-detail/BookDetailControlPanel';
 import GlobalBookDetailContent from '~/components/global-book-detail/GlobalBookDetailContent';
 import { commitSession, getSession } from '~/services/session.server';
-import { ActionResponse } from '../home._index/route';
+import { ActionResponse } from '~/types/response';
 
 interface LoaderData {
 	searchBooksResponse: searchBooksResponse;
@@ -29,7 +29,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 	// 書籍の情報を取得する
 	const isbn = params.isbn ?? '';
 	const searchBooksResponse = await searchBooks({ isbn: isbn });
-	//　既に登録済みであるか確認するため
+	// 既に登録済みであるか確認するため
 	if (session.has('user')) {
 		const getBookResponse = await getBooks({ isbn: isbn });
 		if (getBookResponse.data.totalBook > 0) {

--- a/frontend/app/routes/home.users._index/route.tsx
+++ b/frontend/app/routes/home.users._index/route.tsx
@@ -114,8 +114,9 @@ const UsersListPage = () => {
 		navigate(url);
 	};
 
-	const handleLimitChange = (newLimit: number) =>
+	const handleLimitChange = (newLimit: number) => {
 		navigate(`/home/users?limit=${newLimit}`);
+	};
 
 	const handleDeleteUserButtonClick = (id: number) => {
 		fetcher.submit(

--- a/frontend/app/routes/home.users._index/route.tsx
+++ b/frontend/app/routes/home.users._index/route.tsx
@@ -1,0 +1,144 @@
+import {
+	ActionFunctionArgs,
+	json,
+	LoaderFunctionArgs,
+	redirect,
+} from '@remix-run/cloudflare';
+import { useFetcher, useLoaderData, useNavigate } from '@remix-run/react';
+import { deleteUser, getUsers, getUsersResponse } from 'client/client';
+import UsersListComponent from '~/components/users/UsersListComponent';
+import { commitSession, getSession } from '~/services/session.server';
+import { ActionResponse } from '~/types/response';
+
+interface LoaderData {
+	usersResponse: getUsersResponse;
+	condition: {
+		page?: string;
+		limit?: string;
+	};
+}
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+	// 検索条件を取得する
+	const url = new URL(request.url);
+	const page = url.searchParams.get('page') ?? undefined;
+	const limit = url.searchParams.get('limit') ?? undefined;
+	// ユーザー情報を取得する
+	const response = await getUsers({ page: page, limit: limit });
+
+	return json<LoaderData>({
+		usersResponse: response,
+		condition: {
+			page: page,
+			limit: limit,
+		},
+	});
+};
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+	const session = await getSession(request.headers.get('Cookie'));
+	const formData = await request.formData();
+	const userId = String(formData.get('userId'));
+
+	// 未ログインの場合
+	if (!session.has('user')) {
+		session.flash('error', 'ログインしてください');
+		return redirect('/login', {
+			headers: {
+				'Set-Cookie': await commitSession(session),
+			},
+		});
+	}
+
+	const cookieHeader = [
+		`__Secure-user_id=${session.get('user')?.id};`,
+		`__Secure-session_token=${session.get('user')?.sessionToken}`,
+	].join('; ');
+
+	const response = await deleteUser(userId, {
+		headers: { Cookie: cookieHeader },
+	});
+
+	switch (response.status) {
+		case 204:
+			session.flash('success', 'ユーザーを削除しました');
+			if (Number(userId) === session.get('user')?.id) {
+				session.unset('user');
+				session.flash('success', 'ログアウトしました');
+				return redirect('/home', {
+					headers: {
+						'Set-Cookie': await commitSession(session),
+					},
+				});
+			}
+			break;
+		case 401:
+			session.flash('error', 'ログインしてください');
+			return redirect('/login', {
+				headers: {
+					'Set-Cookie': await commitSession(session),
+				},
+			});
+		case 404:
+			session.flash('error', 'ユーザーが見つかりませんでした');
+			break;
+		case 500:
+			session.flash('error', 'サーバーエラーが発生しました');
+			break;
+	}
+	return json<ActionResponse>(
+		{ method: 'DELETE', status: response.status },
+		{
+			headers: {
+				'Set-Cookie': await commitSession(session),
+			},
+		},
+	);
+};
+
+const UsersListPage = () => {
+	const { usersResponse, condition } = useLoaderData<typeof loader>();
+	const { page, limit } = condition;
+	const navigate = useNavigate();
+	const fetcher = useFetcher();
+	const handlePaginationChange = (newPage: number) => {
+		let url = '/home/users';
+		let initial = true;
+		if (limit) {
+			url =
+				initial === true ? `${url}?limit=${limit}` : `${url}&limit=${limit}`;
+			initial = false;
+		}
+		url =
+			initial === true ? `${url}?page=${newPage}` : `${url}&page=${newPage}`;
+		navigate(url);
+	};
+
+	const handleLimitChange = (newLimit: number) =>
+		navigate(`/home/users?limit=${newLimit}`);
+
+	const handleDeleteUserButtonClick = (id: number) => {
+		fetcher.submit(
+			{ userId: id },
+			{
+				method: 'DELETE',
+			},
+		);
+	};
+
+	return (
+		<UsersListComponent
+			paginationProps={{
+				handlePaginationChange: handlePaginationChange,
+				handleLimitChange: handleLimitChange,
+				page: page ? Number(page) : undefined,
+				limit: limit ? Number(limit) : undefined,
+				totalNum: usersResponse.data.totalUser,
+			}}
+			usersResponse={usersResponse}
+			handleDeleteUserButtonClick={handleDeleteUserButtonClick}
+		/>
+	);
+};
+
+export default UsersListPage;

--- a/frontend/app/routes/home.users._index/route.tsx
+++ b/frontend/app/routes/home.users._index/route.tsx
@@ -133,7 +133,7 @@ const UsersListPage = () => {
 				handleLimitChange: handleLimitChange,
 				page: page ? Number(page) : undefined,
 				limit: limit ? Number(limit) : undefined,
-				totalNum: usersResponse.data.totalUser,
+				total: usersResponse.data.totalUser,
 			}}
 			usersResponse={usersResponse}
 			handleDeleteUserButtonClick={handleDeleteUserButtonClick}

--- a/frontend/app/routes/home.users/route.tsx
+++ b/frontend/app/routes/home.users/route.tsx
@@ -1,4 +1,19 @@
+import { LoaderFunctionArgs, redirect } from '@remix-run/cloudflare';
 import { Outlet } from '@remix-run/react';
+import { commitSession, getSession } from '~/services/session.server';
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+	const session = await getSession(request.headers.get('Cookie'));
+
+	if (!session.has('user')) {
+		return redirect('/login', {
+			headers: {
+				'Set-Cookie': await commitSession(session),
+			},
+		});
+	}
+	return null;
+};
 
 const UsersLayout = () => {
 	return <Outlet />;

--- a/frontend/app/routes/home.users/route.tsx
+++ b/frontend/app/routes/home.users/route.tsx
@@ -1,0 +1,7 @@
+import { Outlet } from '@remix-run/react';
+
+const UsersLayout = () => {
+	return <Outlet />;
+};
+
+export default UsersLayout;

--- a/frontend/app/routes/home/route.tsx
+++ b/frontend/app/routes/home/route.tsx
@@ -101,7 +101,7 @@ const Home = () => {
 
 	useEffect(() => {
 		if (navigation.state === 'idle') {
-			if (!!userData) {
+			if (userData) {
 				// Cookieにユーザ情報が保存されている
 				if (!user) {
 					// 状態変数にユーザ情報を保存する

--- a/frontend/app/types/modal.d.ts
+++ b/frontend/app/types/modal.d.ts
@@ -1,0 +1,5 @@
+export interface HandleModalProps {
+	isOpen: boolean;
+	open: () => void;
+	close: () => void;
+}

--- a/frontend/app/types/paginatiion.d.ts
+++ b/frontend/app/types/paginatiion.d.ts
@@ -1,0 +1,7 @@
+export interface PaginationProps {
+	handlePaginationChange: (newPage: number) => void;
+	handleLimitChange: (newLimit: number) => void;
+	page?: number;
+	limit?: number;
+	totalNum: number;
+}

--- a/frontend/app/types/paginatiion.d.ts
+++ b/frontend/app/types/paginatiion.d.ts
@@ -3,5 +3,5 @@ export interface PaginationProps {
 	handleLimitChange: (newLimit: number) => void;
 	page?: number;
 	limit?: number;
-	totalNum: number;
+	total: number;
 }

--- a/frontend/app/types/response.d.ts
+++ b/frontend/app/types/response.d.ts
@@ -1,0 +1,4 @@
+export interface ActionResponse {
+	method: string;
+	status: number;
+}


### PR DESCRIPTION
<!-- Closeするissue番号 -->
- Close #70 
- Close #139 

## やったこと

- やったこと (コミットのハッシュ)
- Paginationやアクションレスポンスのタイプを切り分ける 85cc37402807e234c933c00f6614aa2ea5123913
- ユーザー一覧ページの実装 d6c92787561acbce5ce0e8b5a76df1c4870ac6e8

## 確認した方法

- `pnpm run dev`で動かした

## スクリーンショット

![image](https://github.com/user-attachments/assets/16f2e9b2-f86a-4d2f-886d-bfdfcf5f477e)




## 自動生成したコード

- ファイル名
