### PR TITLE
ユーザ更新時にパスワードのバリデーションをかける

### DIFF
--- a/api/bundle.yml
+++ b/api/bundle.yml
@@ -673,7 +673,12 @@ paths:
                 email:
                   type: string
                   format: email
-                password:
+                currentPassword:
+                  type: string
+                  format: password
+                  pattern: ^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]+$
+                  minLength: 8
+                newPassword:
                   type: string
                   format: password
                   pattern: ^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]+$
@@ -681,7 +686,8 @@ paths:
             example:
               name: 比企谷八幡
               email: hikigaya@oregairu.com
-              password: passw0rd
+              currentPassword: passw0rd
+              newPassword: pa55word
       responses:
         '200':
           description: 情報の更新に成功した
@@ -1108,3 +1114,4 @@ components:
         id: 1
         name: 比企谷八幡
         email: hikigaya@oregairu.com
+        sessionToken: abcde12345

--- a/api/components/examples/user.yml
+++ b/api/components/examples/user.yml
@@ -1,4 +1,5 @@
 value:
   id: 1
-  name: "比企谷八幡"
-  email: "hikigaya@oregairu.com"
+  name: '比企谷八幡'
+  email: 'hikigaya@oregairu.com'
+  sessionToken: 'abcde12345'

--- a/api/paths/user.yml
+++ b/api/paths/user.yml
@@ -221,7 +221,12 @@ user:
               email:
                 type: string
                 format: email
-              password:
+              currentPassword:
+                type: string
+                format: password
+                pattern: ^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]+$
+                minLength: 8
+              newPassword:
                 type: string
                 format: password
                 pattern: ^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]+$
@@ -229,7 +234,8 @@ user:
           example:
             name: '比企谷八幡'
             email: 'hikigaya@oregairu.com'
-            password: 'passw0rd'
+            currentPassword: 'passw0rd'
+            newPassword: 'pa55word'
     responses:
       '200':
         description: 情報の更新に成功した

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -261,15 +261,19 @@ export const updateUserParams = zod.object({
   "userId": zod.string().regex(updateUserPathUserIdRegExp)
 })
 
-export const updateUserBodyPasswordMin = 8;
+export const updateUserBodyCurrentPasswordMin = 8;
 
-export const updateUserBodyPasswordRegExp = new RegExp('^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]+$');
+export const updateUserBodyCurrentPasswordRegExp = new RegExp('^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]+$');
+export const updateUserBodyNewPasswordMin = 8;
+
+export const updateUserBodyNewPasswordRegExp = new RegExp('^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]+$');
 
 
 export const updateUserBody = zod.object({
   "name": zod.string().optional(),
   "email": zod.string().email().optional(),
-  "password": zod.string().min(updateUserBodyPasswordMin).regex(updateUserBodyPasswordRegExp).optional()
+  "currentPassword": zod.string().min(updateUserBodyCurrentPasswordMin).regex(updateUserBodyCurrentPasswordRegExp).optional(),
+  "newPassword": zod.string().min(updateUserBodyNewPasswordMin).regex(updateUserBodyNewPasswordRegExp).optional()
 })
 
 export const updateUserResponse = zod.object({

--- a/frontend/client/client.schemas.ts
+++ b/frontend/client/client.schemas.ts
@@ -86,13 +86,18 @@ export type DeleteUser204 = {
 };
 
 export type UpdateUserBody = {
+  /**
+   * @minLength 8
+   * @pattern ^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]+$
+   */
+  currentPassword?: string;
   email?: string;
   name?: string;
   /**
    * @minLength 8
    * @pattern ^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]+$
    */
-  password?: string;
+  newPassword?: string;
 };
 
 export type DeleteUsersBody = {

--- a/frontend/test/mocks/mock.ts
+++ b/frontend/test/mocks/mock.ts
@@ -1406,11 +1406,11 @@ export const getSearchBooksResponseMock = (): SearchBooks200 => ({"totalBook":30
 
 export const getGetUsersResponseMock = (overrideResponse: Partial< GetUsers200 > = {}): GetUsers200 => ({totalUser: faker.number.int({min: undefined, max: undefined}), users: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({id: faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), undefined]), name: faker.helpers.arrayElement([faker.word.sample(), undefined])})), ...overrideResponse})
 
-export const getCreateUserResponseMock = (): User => ({"id":1,"name":"比企谷八幡","email":"hikigaya@oregairu.com"})
+export const getCreateUserResponseMock = (): User => ({"id":1,"name":"比企谷八幡","email":"hikigaya@oregairu.com","sessionToken":"abcde12345"})
 
-export const getGetUserResponseMock = (): User => ({"id":1,"name":"比企谷八幡","email":"hikigaya@oregairu.com"})
+export const getGetUserResponseMock = (): User => ({"id":1,"name":"比企谷八幡","email":"hikigaya@oregairu.com","sessionToken":"abcde12345"})
 
-export const getUpdateUserResponseMock = (): User => ({"id":1,"name":"比企谷八幡","email":"hikigaya@oregairu.com"})
+export const getUpdateUserResponseMock = (): User => ({"id":1,"name":"比企谷八幡","email":"hikigaya@oregairu.com","sessionToken":"abcde12345"})
 
 export const getDeleteUserResponseMock = (): DeleteUser204 => ({"message":"No Content"})
 
@@ -1418,7 +1418,7 @@ export const getGetLoansResponseMock = (overrideResponse: Partial< GetLoans200 >
 
 export const getUpsertLoansResponseMock = (): Loan[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({bookId: faker.number.int({min: undefined, max: undefined}), createdAt: faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), undefined]), updatedAt: faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), undefined]), userId: faker.number.int({min: undefined, max: undefined}), volume: faker.number.int({min: undefined, max: undefined})})))
 
-export const getLoginResponseMock = (): User => ({"id":1,"name":"比企谷八幡","email":"hikigaya@oregairu.com"})
+export const getLoginResponseMock = (): User => ({"id":1,"name":"比企谷八幡","email":"hikigaya@oregairu.com","sessionToken":"abcde12345"})
 
 
 export const getGetBooksMockHandler = (overrideResponse?: GetBooks200 | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<GetBooks200> | GetBooks200)) => {

--- a/frontend/test/mocks/model/updateUserBody.ts
+++ b/frontend/test/mocks/model/updateUserBody.ts
@@ -6,11 +6,16 @@
  */
 
 export type UpdateUserBody = {
+  /**
+   * @minLength 8
+   * @pattern ^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]+$
+   */
+  currentPassword?: string;
   email?: string;
   name?: string;
   /**
    * @minLength 8
    * @pattern ^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]+$
    */
-  password?: string;
+  newPassword?: string;
 };


### PR DESCRIPTION
<!-- Closeするissue番号 -->
- Close #136 

## やったこと

- PATCH /users/:userIdのレスポンスボディの仕様を変更した e687a399bec071c08af8de3b0101c6858c705205
- APIの実装を変更した 6441799979d417d1eb8a78b6c8cdfb06e36138b2

## 確認した方法

- Thunder Client
- テストコード
