### PR TITLE
ユーザ一覧ページのページネーション上部の間隔を空けた

### DIFF
--- a/frontend/app/components/common/pagination/ContentsHeader.tsx
+++ b/frontend/app/components/common/pagination/ContentsHeader.tsx
@@ -10,15 +10,13 @@ interface ContentsHeaderProps {
 }
 
 const ContentsHeader = ({
-	page,
-	limit,
+	page = 1,
+	limit = 10,
 	total,
 	handleLimitChange,
 }: ContentsHeaderProps) => {
-	const truePage = page ?? 1;
-	const trueLimit = limit ?? 10;
-	const start = (truePage - 1) * trueLimit + 1;
-	const stop = truePage * trueLimit;
+	const start = (page - 1) * limit + 1;
+	const stop = page * limit;
 
 	return (
 		<Group justify="space-between">

--- a/frontend/app/components/users/UsersListComponent.tsx
+++ b/frontend/app/components/users/UsersListComponent.tsx
@@ -1,4 +1,4 @@
-import { Container, Stack } from '@mantine/core';
+import { Stack } from '@mantine/core';
 import { SerializeFrom } from '@remix-run/cloudflare';
 import { getUsersResponse } from 'client/client';
 import type { PaginationProps } from '~/types/pagination';
@@ -19,14 +19,9 @@ const UsersListComponent = ({
 	usersResponse,
 }: UsersListComponentProps) => {
 	return (
-		<Container>
-			<Stack
-				bg="var(--mantine-color-body)"
-				align="center"
-				justify="center"
-				maw="100%"
-			>
-				<UsersListTitle />
+		<Stack bg="var(--mantine-color-body)" align="center" justify="flex-start">
+			<UsersListTitle />
+			<Stack w={{ base: '70%', md: '50%' }} align="stretch">
 				<ContentsHeader
 					page={paginationProps.page}
 					limit={paginationProps.limit}
@@ -38,15 +33,15 @@ const UsersListComponent = ({
 				) : (
 					<ErrorComponent message={'ユーザー情報を取得できませんでした。'} />
 				)}
-				<UserCreateButton />
-				<PaginationComponent
-					total={paginationProps.total}
-					page={paginationProps.page}
-					limit={paginationProps.limit}
-					handlePaginationChange={paginationProps.handlePaginationChange}
-				/>
 			</Stack>
-		</Container>
+			<UserCreateButton />
+			<PaginationComponent
+				total={paginationProps.total}
+				page={paginationProps.page}
+				limit={paginationProps.limit}
+				handlePaginationChange={paginationProps.handlePaginationChange}
+			/>
+		</Stack>
 	);
 };
 

--- a/frontend/app/components/users/UsersListTable.tsx
+++ b/frontend/app/components/users/UsersListTable.tsx
@@ -1,4 +1,4 @@
-import { rem, Table } from '@mantine/core';
+import { Table } from '@mantine/core';
 import { GetUsers200UsersItem } from 'client/client.schemas';
 import NoUserComponent from './NoUserComponent';
 import UserDeleteButton from './UserDeleteButton';
@@ -12,14 +12,14 @@ const UsersListTable = ({ users }: UsersTableProps) => {
 		return <NoUserComponent />;
 	}
 	return (
-		<Table striped maw="50%">
+		<Table striped>
 			<Table.Tbody>
 				{users.map((user) => (
 					<Table.Tr key={user.id}>
 						{user.id && (
 							<>
 								<Table.Td fz="md">{user.name}</Table.Td>
-								<Table.Td maw={rem(5)}>
+								<Table.Td ta="right">
 									<UserDeleteButton id={user.id} />
 								</Table.Td>
 							</>

--- a/frontend/app/routes/home/route.tsx
+++ b/frontend/app/routes/home/route.tsx
@@ -128,7 +128,7 @@ const Home = () => {
 	}, [error]);
 
 	return (
-		<AppShell header={{ height: 70 }} padding={{ default: 'md', sm: 'sm' }}>
+		<AppShell header={{ height: 70 }} padding="md">
 			<HeaderComponent />
 			<Container size="xl">
 				<AppShell.Main>

--- a/frontend/test/routes/home.books.bookId/route.test.tsx
+++ b/frontend/test/routes/home.books.bookId/route.test.tsx
@@ -97,9 +97,9 @@ describe('Book Detail Page', () => {
 					'Set-Cookie': expect.any(String),
 				},
 			});
-
-			// TODO: ログイン状態で削除ボタンをクリックした場合
 		});
+
+		// TODO: ログイン状態で削除ボタンをクリックした場合
 	});
 
 	describe('Book Detail', () => {


### PR DESCRIPTION
<!-- Closeするissue番号 -->
- Close #167 

## やったこと

- `ContentsHeaderProps` のデフォルト値を設定した d107d345977308533d5ee4fd8c1a8cb8145ec457
- ユーザ一覧ページのページネーション上部の間隔を空けた 2a88524580542855ea8061b361a487de53375898
- `AppShell` の padding を変更した 224536171e3602a0c38336d9d6416fcf89a95be4

画面幅を狭めると padding が足りなくてページタイトルがヘッダーで隠れてしまっていたため

## 確認した方法

```
pnpm run dev
```

## スクリーンショット

![image](https://github.com/user-attachments/assets/e47e1297-4c34-4133-9233-df1b9aa4625e)
