### PR TITLE
JANコードからISBNを読み取れるようにした

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -41,6 +41,7 @@ module.exports = {
 
 			rules: {
 				'react/prop-types': 'off',
+				'react-hooks/exhaustive-deps': 'off',
 			},
 
 			settings: {

--- a/frontend/app/components/book-search/BookSearchIsbnForm.tsx
+++ b/frontend/app/components/book-search/BookSearchIsbnForm.tsx
@@ -1,6 +1,9 @@
-import { TextInput } from '@mantine/core';
+import { Button, Group, rem, Text, TextInput } from '@mantine/core';
 import type { UseFormReturnType } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
 import type { GetBooksParams } from 'client/client.schemas';
+import { MdCameraAlt } from 'react-icons/md';
+import IsbnScanModal from '../common/isbn-scan-modal/IsbnScanModal';
 
 interface SearchIsbnFormProps {
 	form: UseFormReturnType<
@@ -10,14 +13,29 @@ interface SearchIsbnFormProps {
 }
 
 const BookSearchIsbnForm = ({ form }: SearchIsbnFormProps) => {
+	const [opened, { open, close }] = useDisclosure();
+
 	return (
-		<TextInput
-			label="ISBN"
-			placeholder="10桁または13桁のISBN"
-			key={form.key('isbn')}
-			aria-label="ISBN"
-			{...form.getInputProps('isbn')}
-		/>
+		<>
+			<IsbnScanModal url="/home" disclosure={{ opened, close }} />
+			<TextInput
+				label={
+					<Group>
+						<Text>ISBN</Text>
+						<Button variant="transparent" onClick={open}>
+							<MdCameraAlt size={24} />
+							<Text td="underline" ml={rem(5)}>
+								バーコードを読み取る
+							</Text>
+						</Button>
+					</Group>
+				}
+				placeholder="10桁または13桁のISBN"
+				key={form.key('isbn')}
+				aria-label="ISBN"
+				{...form.getInputProps('isbn')}
+			/>
+		</>
 	);
 };
 

--- a/frontend/app/components/common/isbn-scan-modal/BarcodeScanner.tsx
+++ b/frontend/app/components/common/isbn-scan-modal/BarcodeScanner.tsx
@@ -1,0 +1,21 @@
+import { useZxing } from 'react-zxing';
+
+type BarcodeScannerProps = {
+	onScan: (isbn: string) => void;
+};
+
+const BarcodeScanner = ({ onScan }: BarcodeScannerProps) => {
+	const { ref } = useZxing({
+		onDecodeResult(result) {
+			onScan(result.getText());
+		},
+	});
+
+	return (
+		<video ref={ref}>
+			<track kind="captions" />
+		</video>
+	);
+};
+
+export default BarcodeScanner;

--- a/frontend/app/components/common/isbn-scan-modal/IsbnScanModal.tsx
+++ b/frontend/app/components/common/isbn-scan-modal/IsbnScanModal.tsx
@@ -1,0 +1,53 @@
+import { Button, Group, Modal, Stack, Text, TextInput } from '@mantine/core';
+import { useNavigate } from '@remix-run/react';
+import { useState } from 'react';
+import { FaSearch } from 'react-icons/fa';
+import { errorNotification } from '~/utils/notification';
+import BarcodeScanner from './BarcodeScanner';
+
+interface IsbnScanModalProps {
+	url: string;
+	disclosure: {
+		opened: boolean;
+		close: () => void;
+	};
+}
+
+const IsbnScanModal = ({
+	url: url,
+	disclosure: { opened, close },
+}: IsbnScanModalProps) => {
+	const [isbn, setIsbn] = useState('');
+	const navigate = useNavigate();
+
+	return (
+		<Modal opened={opened} onClose={close} size="xl" centered>
+			<Stack align="center">
+				<Text size="lg">バーコードを中央付近に写してください</Text>
+				<BarcodeScanner onScan={setIsbn} />
+				<Group>
+					<Text size="lg">読み取り結果:</Text>
+					<TextInput size="md" value={isbn} />
+					<Button
+						leftSection={<FaSearch />}
+						px={20}
+						fz="lg"
+						onClick={() => {
+							if (isbn !== '') {
+								close();
+								navigate(`${url}?isbn=${isbn}`);
+								setIsbn('');
+							} else {
+								errorNotification('ISBNを読み取ってください');
+							}
+						}}
+					>
+						検索
+					</Button>
+				</Group>
+			</Stack>
+		</Modal>
+	);
+};
+
+export default IsbnScanModal;

--- a/frontend/app/components/global-books/GlobalBookSearchIsbnForm.tsx
+++ b/frontend/app/components/global-books/GlobalBookSearchIsbnForm.tsx
@@ -1,6 +1,9 @@
-import { TextInput } from '@mantine/core';
+import { Button, Group, Text, TextInput, rem } from '@mantine/core';
 import type { UseFormReturnType } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
 import type { SearchGoogleBooksParams } from 'client/client.schemas';
+import { MdCameraAlt } from 'react-icons/md';
+import IsbnScanModal from '../common/isbn-scan-modal/IsbnScanModal';
 
 interface GlobalSearchIsbnFormProps {
 	form: UseFormReturnType<
@@ -10,13 +13,28 @@ interface GlobalSearchIsbnFormProps {
 }
 
 const GlobalBookSearchIsbnForm = ({ form }: GlobalSearchIsbnFormProps) => {
+	const [opened, { open, close }] = useDisclosure();
+
 	return (
-		<TextInput
-			label="ISBN"
-			placeholder="10桁または13桁のISBN"
-			key={form.key('isbn')}
-			{...form.getInputProps('isbn')}
-		/>
+		<>
+			<IsbnScanModal url="/home/global" disclosure={{ opened, close }} />
+			<TextInput
+				label={
+					<Group>
+						<Text>ISBN</Text>
+						<Button variant="transparent" onClick={open}>
+							<MdCameraAlt size={24} />
+							<Text td="underline" ml={rem(5)}>
+								バーコードを読み取る
+							</Text>
+						</Button>
+					</Group>
+				}
+				placeholder="10桁または13桁のISBN"
+				key={form.key('isbn')}
+				{...form.getInputProps('isbn')}
+			/>
+		</>
 	);
 };
 

--- a/frontend/app/routes/home._index/route.tsx
+++ b/frontend/app/routes/home._index/route.tsx
@@ -135,10 +135,22 @@ const BooKListPage = () => {
 		},
 	});
 
+	// 検索条件が変更されたらフォームの値を更新する
 	useEffect(() => {
-		// 選択中の書籍をリセットする
-		setSelectedBook([]);
-	}, []);
+		const formValues = form.getValues();
+
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const { page, limit, ...rest } = condition;
+
+		Object.entries(rest).forEach(([key, value]) => {
+			const currentValue = formValues[key as keyof GetBooksParams];
+			if (currentValue !== value) {
+				form.setFieldValue(key, value);
+			}
+		});
+	}, [condition]);
+
+	useEffect(() => setSelectedBook([]), []);
 
 	const handleSubmit = (props: GetBooksParams) => {
 		const params = new URLSearchParams();

--- a/frontend/app/routes/home.cart/route.tsx
+++ b/frontend/app/routes/home.cart/route.tsx
@@ -84,10 +84,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 const CartListPage = () => {
 	const [, setSelectedCartBook] = useAtom(selectedCartBooksAtom);
 
-	useEffect(() => {
-		// 選択中の書籍をリセットする
-		setSelectedCartBook([]);
-	}, []);
+	useEffect(() => setSelectedCartBook([]), []);
 
 	return <CartListComponent />;
 };

--- a/frontend/app/routes/home.global._index/route.tsx
+++ b/frontend/app/routes/home.global._index/route.tsx
@@ -5,7 +5,7 @@ import { json } from '@remix-run/cloudflare';
 import { useLoaderData, useNavigate } from '@remix-run/react';
 import { searchGoogleBooks, searchGoogleBooksResponse } from 'client/client';
 import { SearchGoogleBooksParams } from 'client/client.schemas';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import GlobalBookListComponent from '~/components/global-books/GlobalBookListComponent';
 
 interface LoaderData {
@@ -96,8 +96,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 const GlobalBookListPage = () => {
 	const { booksResponse, condition } = useLoaderData<typeof loader>();
 	const { keyword, title, author, publisher, isbn, page, limit } = condition;
-	const [opened, { open, close }] = useDisclosure();
+
 	const [searchMode, setSearchMode] = useState(keyword ? 'keyword' : 'detail');
+	const [opened, { open, close }] = useDisclosure();
 	const navigate = useNavigate();
 	const form = useForm<SearchGoogleBooksParams>({
 		mode: 'uncontrolled',
@@ -109,6 +110,21 @@ const GlobalBookListPage = () => {
 			isbn: isbn ?? '',
 		},
 	});
+
+	// 検索条件が変更されたらフォームの値を更新する
+	useEffect(() => {
+		const formValues = form.getValues();
+
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const { page, limit, ...rest } = condition;
+
+		Object.entries(rest).forEach(([key, value]) => {
+			const currentValue = formValues[key as keyof SearchGoogleBooksParams];
+			if (currentValue !== value) {
+				form.setFieldValue(key, value);
+			}
+		});
+	}, [condition]);
 
 	const handleDetailSubmit = (props: SearchGoogleBooksParams) => {
 		const params = new URLSearchParams();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,8 @@
 		"jsonpath-plus": "^10.0.0",
 		"react": "19.0.0-rc-09111202-20241011",
 		"react-dom": "19.0.0-rc-09111202-20241011",
-		"react-icons": "^5.3.0"
+		"react-icons": "^5.3.0",
+		"react-zxing": "^2.0.2"
 	},
 	"overrides": {
 		"@types/react": "npm:types-react@rc",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       react-icons:
         specifier: ^5.3.0
         version: 5.3.0(react@19.0.0-rc-09111202-20241011)
+      react-zxing:
+        specifier: ^2.0.2
+        version: 2.0.2(react-dom@19.0.0-rc-09111202-20241011(react@19.0.0-rc-09111202-20241011))(react@19.0.0-rc-09111202-20241011)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20241004.0
@@ -1676,6 +1679,10 @@ packages:
 
   '@web3-storage/multipart-parser@1.0.0':
     resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
+
+  '@zxing/library@0.20.0':
+    resolution: {integrity: sha512-6Ev6rcqVjMakZFIDvbUf0dtpPGeZMTfyxYg4HkVWioWeN7cRcnUWT3bU6sdohc82O1nPXcjq6WiGfXX2Pnit6A==}
+    engines: {node: '>= 10.4.0'}
 
   '@zxing/text-encoding@0.9.0':
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
@@ -4111,6 +4118,13 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
 
+  react-zxing@2.0.2:
+    resolution: {integrity: sha512-6TRXPL+QESjVQOCAZVRT2pUf/Fz3t4nPfbQLvNH42Dy9r/bu1rJq1I/lCUY+fK2Wg3mvLxPxym2AzzOM32mcmg==}
+    engines: {node: ^18 || ^20 || ^22, yarn: ^1.22}
+    peerDependencies:
+      react: ^16.8.0  || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+
   react@19.0.0-rc-09111202-20241011:
     resolution: {integrity: sha512-kAz5u4PAPQJI2VJzUrYC/p82CoPcl/KD7i1tHe+nu3RezaAvHGCZY339bLFMBzY91jnJoo07JQZ6UsqivtQ2vQ==}
     engines: {node: '>=0.10.0'}
@@ -4609,6 +4623,10 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+
+  ts-custom-error@3.3.1:
+    resolution: {integrity: sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==}
+    engines: {node: '>=14.0.0'}
 
   tsconfck@2.1.2:
     resolution: {integrity: sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==}
@@ -6768,6 +6786,12 @@ snapshots:
       tinyrainbow: 1.2.0
 
   '@web3-storage/multipart-parser@1.0.0': {}
+
+  '@zxing/library@0.20.0':
+    dependencies:
+      ts-custom-error: 3.3.1
+    optionalDependencies:
+      '@zxing/text-encoding': 0.9.0
 
   '@zxing/text-encoding@0.9.0':
     optional: true
@@ -9692,6 +9716,12 @@ snapshots:
       react: 19.0.0-rc-09111202-20241011
       react-dom: 19.0.0-rc-09111202-20241011(react@19.0.0-rc-09111202-20241011)
 
+  react-zxing@2.0.2(react-dom@19.0.0-rc-09111202-20241011(react@19.0.0-rc-09111202-20241011))(react@19.0.0-rc-09111202-20241011):
+    dependencies:
+      '@zxing/library': 0.20.0
+      react: 19.0.0-rc-09111202-20241011
+      react-dom: 19.0.0-rc-09111202-20241011(react@19.0.0-rc-09111202-20241011)
+
   react@19.0.0-rc-09111202-20241011: {}
 
   readable-stream@2.3.8:
@@ -10280,6 +10310,8 @@ snapshots:
   ts-api-utils@1.3.0(typescript@5.6.2):
     dependencies:
       typescript: 5.6.2
+
+  ts-custom-error@3.3.1: {}
 
   tsconfck@2.1.2(typescript@5.6.2):
     optionalDependencies:

--- a/frontend/test/routes/home._index/route.test.tsx
+++ b/frontend/test/routes/home._index/route.test.tsx
@@ -64,7 +64,8 @@ describe('Book List Page', () => {
 			const publisherInput = await screen.findByLabelText('出版社');
 			await user.type(publisherInput, condition.publisher);
 
-			const isbnInput = await screen.findByLabelText('ISBN');
+			// prettier-ignore
+			const isbnInput = await screen.findByPlaceholderText('10桁または13桁のISBN');
 			await user.type(isbnInput, condition.isbn);
 
 			const submitButton = await screen.findByRole('button', { name: '検索' });


### PR DESCRIPTION
<!-- Closeするissue番号 -->
- Close #46

## やったこと

- `reaxt-zxing` をインストールした 2950c9523f6f49b5fc0e4e700e1420d3da440a45
- バーコードを読み取るモーダルを実装した f14fb76c35422736fc004a4049308d3ac9647e4e
- 蔵書一覧ページにモーダルを開くボタンを追加した 8ae282cca72e7f5b268b7ea9b2ed8a1c2cc4be4b
- グローバル検索ページにモーダルを開くボタンを追加した 6abdb95f2f6362b962751630b71fa6cbce9f5ccb

## 確認した方法

```
pnpm run dev
```

## スクリーンショット

### 蔵書一覧ページ

<img src="https://github.com/user-attachments/assets/2ecd2eca-71d9-4535-bdc5-aea26b69e93b" width="600">
<img src="https://github.com/user-attachments/assets/71f7439d-d13b-4710-a5f9-77892b56370c" width="600">


